### PR TITLE
feat: integrate next-auth for login

### DIFF
--- a/src/actions/api.ts
+++ b/src/actions/api.ts
@@ -1,15 +1,22 @@
 'use server';
 
 import { headers } from 'next/headers';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 
 export async function apiFetch(endpoint: string, options?: RequestInit) {
   const host = headers().get('host');
   const protocol = process.env.NODE_ENV === 'production' ? 'https' : 'http';
+  const session = await getServerSession(authOptions);
+
   const res = await fetch(`${protocol}://${host}/api${endpoint}`, {
     cache: 'no-store',
     ...options,
     headers: {
       'Content-Type': 'application/json',
+      ...(session?.accessToken
+        ? { Authorization: `Bearer ${session.accessToken}` }
+        : {}),
       ...(options?.headers || {}),
     },
   });

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,6 @@
+import NextAuth from 'next-auth';
+import { authOptions } from '@/lib/auth';
+
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import SessionProviderWrapper from '@/components/session-provider';
 import "./globals.css";
 
 const geistSans = Geist({
@@ -27,7 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <SessionProviderWrapper>{children}</SessionProviderWrapper>
       </body>
     </html>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { signIn } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await signIn('credentials', {
+      email,
+      password,
+      redirect: false,
+    });
+
+    if (res?.error) {
+      setError('Login gagal');
+    } else {
+      router.push('/');
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+        <h1 className="text-2xl font-bold text-center">Login</h1>
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+          className="w-full border px-3 py-2 rounded"
+          required
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          className="w-full border px-3 py-2 rounded"
+          required
+        />
+        <button
+          type="submit"
+          className="w-full bg-blue-600 text-white py-2 rounded"
+        >
+          Masuk
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/components/session-provider.tsx
+++ b/src/components/session-provider.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { SessionProvider } from 'next-auth/react';
+
+export default function SessionProviderWrapper({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,56 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { NextAuthOptions } from 'next-auth';
+import Credentials from 'next-auth/providers/credentials';
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    Credentials({
+      name: 'Credentials',
+      credentials: {
+        email: { label: 'Email', type: 'email' },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/auth/login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            email: credentials?.email,
+            password: credentials?.password,
+          }),
+        });
+
+        const json = await res.json().catch(() => null);
+        const data = json?.data;
+        if (!res.ok || !data) {
+          return null;
+        }
+
+        return {
+          ...data.user,
+          accessToken: data.token,
+        } as any;
+      },
+    }),
+  ],
+  session: {
+    strategy: 'jwt',
+  },
+  callbacks: {
+    jwt({ token, user }) {
+      if (user) {
+        return { ...token, ...user, accessToken: (user as any).accessToken };
+      }
+      return token;
+    },
+    session({ session, token }) {
+      (session as any).user = token;
+      (session as any).accessToken = (token as any).accessToken;
+      return session;
+    },
+  },
+  pages: {
+    signIn: '/login',
+  },
+  secret: process.env.NEXTAUTH_SECRET,
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,5 @@
+export { default } from 'next-auth/middleware';
+
+export const config = {
+  matcher: ['/((?!api|_next|favicon.ico|login).*)'],
+};

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,15 +1,19 @@
 /** @format */
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import axios from "axios";
+import { getSession } from "next-auth/react";
 
 const api = axios.create({
   baseURL: "/api",
 });
 
-api.interceptors.request.use((config) => {
-  if (typeof window !== "undefined") {
-    const token = localStorage.getItem("accessToken");
-    if (token) config.headers.Authorization = `Bearer ${token}`;
+api.interceptors.request.use(async (config) => {
+  const session = await getSession();
+  const token = (session as any)?.accessToken;
+  if (token) {
+    config.headers = config.headers ?? {};
+    (config.headers as any).Authorization = `Bearer ${token}`;
   }
   return config;
 });


### PR DESCRIPTION
## Summary
- configure next-auth credential provider and expose auth API route
- add login page and session provider wrapping app
- forward session token to backend requests and protect routes via middleware

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68979387951883228d324169829b1ffc