### PR TITLE
Restrict sidebar to authenticated routes and add public landing page

### DIFF
--- a/src/app/(main-route)/layout.tsx
+++ b/src/app/(main-route)/layout.tsx
@@ -1,9 +1,34 @@
 /** @format */
 
 import React from "react";
+import { AppSidebar } from "@/components/shared/app-sidebar";
+import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
+import { SiteHeader } from "@/components/shared/site-header";
 
-function MainLayout() {
-  return <div>MainLayout</div>;
+export default function MainLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <SidebarProvider
+      style={{
+        "--sidebar-width": "calc(var(--spacing) * 72)",
+        "--header-height": "calc(var(--spacing) * 12)",
+      } as React.CSSProperties}
+    >
+      <AppSidebar variant="inset" />
+      <SidebarInset>
+        <SiteHeader />
+        <div className="flex flex-1 flex-col">
+          <div className="@container/main flex flex-1 flex-col gap-2">
+            <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
+              {children}
+            </div>
+          </div>
+        </div>
+      </SidebarInset>
+    </SidebarProvider>
+  );
 }
 
-export default MainLayout;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,9 +4,6 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import SessionProviderWrapper from "@/components/session-provider";
 import "./globals.css";
-import { AppSidebar } from "@/components/shared/app-sidebar";
-import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
-import { SiteHeader } from "@/components/shared/site-header";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -33,28 +30,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <SessionProviderWrapper>
-          <SidebarProvider
-            style={
-              {
-                "--sidebar-width": "calc(var(--spacing) * 72)",
-                "--header-height": "calc(var(--spacing) * 12)",
-              } as React.CSSProperties
-            }
-          >
-            <AppSidebar variant="inset" />
-            <SidebarInset>
-              <SiteHeader />
-              <div className="flex flex-1 flex-col">
-                <div className="@container/main flex flex-1 flex-col gap-2">
-                  <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
-                    {children}
-                  </div>
-                </div>
-              </div>
-            </SidebarInset>
-          </SidebarProvider>
-        </SessionProviderWrapper>
+        <SessionProviderWrapper>{children}</SessionProviderWrapper>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,19 @@
 /** @format */
 
-function MainPage() {
-  return null;
+import Link from "next/link";
+
+export default function MainPage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-4 text-center">
+      <h1 className="text-3xl font-bold">Koperasi Digital Dashboard</h1>
+      <p>Platform untuk mengelola koperasi secara efektif dan modern.</p>
+      <p className="max-w-md">
+        Informasi harga: Silakan hubungi kami untuk paket keanggotaan dan layanan lainnya.
+      </p>
+      <Link href="/login" className="text-blue-600 underline">
+        Masuk ke aplikasi
+      </Link>
+    </main>
+  );
 }
 
-export default MainPage;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,20 @@
-export { default } from 'next-auth/middleware';
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { getToken } from "next-auth/jwt";
+
+export async function middleware(req: NextRequest) {
+  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+  const { pathname } = req.nextUrl;
+
+  // Allow public routes
+  if (!token && pathname !== "/" && pathname !== "/login") {
+    return NextResponse.redirect(new URL("/", req.url));
+  }
+
+  return NextResponse.next();
+}
 
 export const config = {
-  matcher: ['/((?!api|_next|favicon.ico|login).*)'],
+  matcher: ["/((?!api|_next|favicon.ico).*)"],
 };
+


### PR DESCRIPTION
## Summary
- Move sidebar components to `(main-route)` layout so it only renders for authenticated pages
- Simplify root layout for public pages and add landing page with app info and login link
- Implement middleware to redirect unauthenticated visitors to `/`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6897f867ba8c8322b79f802ec16fcecc