### PR TITLE
feat: add dashboard route protection and sidebar navigation

### DIFF
--- a/src/app/(main-route)/dashboard/page.tsx
+++ b/src/app/(main-route)/dashboard/page.tsx
@@ -1,0 +1,23 @@
+/** @format */
+
+import { getDashboardSummary } from "@/actions/dashboard";
+
+export default async function DashboardPage() {
+  let summary;
+  try {
+    summary = await getDashboardSummary();
+  } catch {
+    summary = null;
+  }
+
+  return (
+    <section className="p-8">
+      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+      {summary ? (
+        <pre className="text-sm bg-muted p-4 rounded">{JSON.stringify(summary, null, 2)}</pre>
+      ) : (
+        <p className="text-sm text-muted-foreground">Summary data is unavailable.</p>
+      )}
+    </section>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -23,7 +23,7 @@ export default function LoginPage() {
     if (res?.error) {
       setError("Login gagal");
     } else {
-      router.push("/");
+      router.push("/dashboard");
     }
   };
 

--- a/src/components/shared/app-sidebar.tsx
+++ b/src/components/shared/app-sidebar.tsx
@@ -4,7 +4,7 @@
 
 import * as React from "react";
 import {
-  IconCamera,
+  IconBell,
   IconChartBar,
   IconDashboard,
   IconDatabase,
@@ -12,12 +12,9 @@ import {
   IconFileDescription,
   IconFileWord,
   IconFolder,
-  IconHelp,
   IconInnerShadowTop,
   IconListDetails,
   IconReport,
-  IconSearch,
-  IconSettings,
   IconUsers,
 } from "@tabler/icons-react";
 
@@ -30,9 +27,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
-import { NavDocuments } from "./nav-documents";
 import { NavMain } from "./nav-main";
-import { NavSecondary } from "./nav-secondary";
 import { NavUser } from "./nav-user";
 
 const data = {
@@ -42,113 +37,17 @@ const data = {
     avatar: "/avatars/shadcn.jpg",
   },
   navMain: [
-    {
-      title: "Dashboard",
-      url: "#",
-      icon: IconDashboard,
-    },
-    {
-      title: "Lifecycle",
-      url: "#",
-      icon: IconListDetails,
-    },
-    {
-      title: "Analytics",
-      url: "#",
-      icon: IconChartBar,
-    },
-    {
-      title: "Projects",
-      url: "#",
-      icon: IconFolder,
-    },
-    {
-      title: "Team",
-      url: "#",
-      icon: IconUsers,
-    },
-  ],
-  navClouds: [
-    {
-      title: "Capture",
-      icon: IconCamera,
-      isActive: true,
-      url: "#",
-      items: [
-        {
-          title: "Active Proposals",
-          url: "#",
-        },
-        {
-          title: "Archived",
-          url: "#",
-        },
-      ],
-    },
-    {
-      title: "Proposal",
-      icon: IconFileDescription,
-      url: "#",
-      items: [
-        {
-          title: "Active Proposals",
-          url: "#",
-        },
-        {
-          title: "Archived",
-          url: "#",
-        },
-      ],
-    },
-    {
-      title: "Prompts",
-      icon: IconFileAi,
-      url: "#",
-      items: [
-        {
-          title: "Active Proposals",
-          url: "#",
-        },
-        {
-          title: "Archived",
-          url: "#",
-        },
-      ],
-    },
-  ],
-  navSecondary: [
-    {
-      title: "Settings",
-      url: "#",
-      icon: IconSettings,
-    },
-    {
-      title: "Get Help",
-      url: "#",
-      icon: IconHelp,
-    },
-    {
-      title: "Search",
-      url: "#",
-      icon: IconSearch,
-    },
-  ],
-  documents: [
-    {
-      name: "Data Library",
-      url: "#",
-      icon: IconDatabase,
-    },
-    {
-      name: "Reports",
-      url: "#",
-      icon: IconReport,
-    },
-    {
-      name: "Word Assistant",
-      url: "#",
-      icon: IconFileWord,
-    },
+    { title: "Dashboard", url: "/dashboard", icon: IconDashboard },
+    { title: "Assets", url: "/assets", icon: IconDatabase },
+    { title: "Billing", url: "/billing", icon: IconReport },
+    { title: "Financing", url: "/financing", icon: IconFileDescription },
+    { title: "Loans", url: "/loans", icon: IconListDetails },
+    { title: "Members", url: "/members", icon: IconUsers },
+    { title: "Notifications", url: "/notifications", icon: IconBell },
+    { title: "RAT", url: "/rat", icon: IconFileWord },
+    { title: "Savings", url: "/savings", icon: IconFolder },
+    { title: "SHU", url: "/shu", icon: IconChartBar },
+    { title: "Transactions", url: "/transactions", icon: IconFileAi },
   ],
 };
 
@@ -172,8 +71,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       </SidebarHeader>
       <SidebarContent>
         <NavMain items={data.navMain} />
-        <NavDocuments items={data.documents} />
-        <NavSecondary items={data.navSecondary} className="mt-auto" />
       </SidebarContent>
       <SidebarFooter>
         <NavUser user={data.user} />

--- a/src/components/shared/nav-main.tsx
+++ b/src/components/shared/nav-main.tsx
@@ -2,6 +2,7 @@
 
 "use client";
 
+import Link from "next/link";
 import { IconCirclePlusFilled, IconMail, type Icon } from "@tabler/icons-react";
 
 import { Button } from "@/components/ui/button";
@@ -47,9 +48,11 @@ export function NavMain({
         <SidebarMenu>
           {items.map((item) => (
             <SidebarMenuItem key={item.title}>
-              <SidebarMenuButton tooltip={item.title}>
-                {item.icon && <item.icon />}
-                <span>{item.title}</span>
+              <SidebarMenuButton asChild tooltip={item.title}>
+                <Link href={item.url}>
+                  {item.icon && <item.icon />}
+                  <span>{item.title}</span>
+                </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>
           ))}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,9 +6,12 @@ export async function middleware(req: NextRequest) {
   const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
   const { pathname } = req.nextUrl;
 
-  // Allow public routes
-  if (!token && pathname !== "/" && pathname !== "/login") {
-    return NextResponse.redirect(new URL("/", req.url));
+  if (token && (pathname === "/" || pathname === "/login")) {
+    return NextResponse.redirect(new URL("/dashboard", req.url));
+  }
+
+  if (!token && pathname !== "/login") {
+    return NextResponse.redirect(new URL("/login", req.url));
   }
 
   return NextResponse.next();


### PR DESCRIPTION
## Summary
- redirect authenticated users to `/dashboard` and guests to `/login`
- send users to dashboard after successful login
- add `/dashboard` page with summary placeholder
- wire sidebar navigation to real routes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689802ac21148322955b4d63b524394e