### PR TITLE
feat: wire dashboard summary into summary cards

### DIFF
--- a/src/app/(main-route)/dashboard/dashboard-content.tsx
+++ b/src/app/(main-route)/dashboard/dashboard-content.tsx
@@ -2,14 +2,20 @@
 
 "use client";
 
-import SummaryCard from "@/components/feature/dashboard/summary-card";
+import SummaryCard, {
+  type DashboardSummary,
+} from "@/components/feature/dashboard/summary-card";
 import { useLanguage } from "@/contexts/language-context";
 
-export default function DashboardContent({ summary }: { summary: any }) {
+export default function DashboardContent({
+  summary,
+}: {
+  summary: DashboardSummary | null;
+}) {
   const { t } = useLanguage();
   return (
     <section>
-      <SummaryCard />
+      <SummaryCard summary={summary} />
       <h1 className="text-2xl font-bold mb-4">{t("dashboard")}</h1>
       {summary ? (
         <pre className="text-sm bg-muted p-4 rounded">

--- a/src/components/feature/dashboard/summary-card.tsx
+++ b/src/components/feature/dashboard/summary-card.tsx
@@ -12,93 +12,66 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 
-export default function SummaryCard() {
+type SummaryItem = {
+  amount: number;
+  change: number;
+};
+
+export type DashboardSummary = {
+  revenue: SummaryItem;
+  expense: SummaryItem;
+  net_profit: SummaryItem;
+  cash_balance: SummaryItem;
+};
+
+export default function SummaryCard({
+  summary,
+}: {
+  summary?: DashboardSummary | null;
+}) {
+  const cards: { title: string; key: keyof DashboardSummary }[] = [
+    { title: "Total Revenue", key: "revenue" },
+    { title: "Total Expense", key: "expense" },
+    { title: "Net Profit", key: "net_profit" },
+    { title: "Cash Balance", key: "cash_balance" },
+  ];
+
   return (
     <div className="*:data-[slot=card]:from-primary/5 *:data-[slot=card]:to-card dark:*:data-[slot=card]:bg-card grid grid-cols-1 gap-4 px-4 *:data-[slot=card]:bg-gradient-to-t *:data-[slot=card]:shadow-xs lg:px-6 @xl/main:grid-cols-2 @5xl/main:grid-cols-4">
-      <Card className="@container/card">
-        <CardHeader>
-          <CardDescription>Total Revenue</CardDescription>
-          <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-            $1,250.00
-          </CardTitle>
-          <CardAction>
-            <Badge variant="outline">
-              <IconTrendingUp />
-              +12.5%
-            </Badge>
-          </CardAction>
-        </CardHeader>
-        <CardFooter className="flex-col items-start gap-1.5 text-sm">
-          <div className="line-clamp-1 flex gap-2 font-medium">
-            Trending up this month <IconTrendingUp className="size-4" />
-          </div>
-          <div className="text-muted-foreground">
-            Visitors for the last 6 months
-          </div>
-        </CardFooter>
-      </Card>
-      <Card className="@container/card">
-        <CardHeader>
-          <CardDescription>New Customers</CardDescription>
-          <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-            1,234
-          </CardTitle>
-          <CardAction>
-            <Badge variant="outline">
-              <IconTrendingDown />
-              -20%
-            </Badge>
-          </CardAction>
-        </CardHeader>
-        <CardFooter className="flex-col items-start gap-1.5 text-sm">
-          <div className="line-clamp-1 flex gap-2 font-medium">
-            Down 20% this period <IconTrendingDown className="size-4" />
-          </div>
-          <div className="text-muted-foreground">
-            Acquisition needs attention
-          </div>
-        </CardFooter>
-      </Card>
-      <Card className="@container/card">
-        <CardHeader>
-          <CardDescription>Active Accounts</CardDescription>
-          <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-            45,678
-          </CardTitle>
-          <CardAction>
-            <Badge variant="outline">
-              <IconTrendingUp />
-              +12.5%
-            </Badge>
-          </CardAction>
-        </CardHeader>
-        <CardFooter className="flex-col items-start gap-1.5 text-sm">
-          <div className="line-clamp-1 flex gap-2 font-medium">
-            Strong user retention <IconTrendingUp className="size-4" />
-          </div>
-          <div className="text-muted-foreground">Engagement exceed targets</div>
-        </CardFooter>
-      </Card>
-      <Card className="@container/card">
-        <CardHeader>
-          <CardDescription>Growth Rate</CardDescription>
-          <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-            4.5%
-          </CardTitle>
-          <CardAction>
-            <Badge variant="outline">
-              <IconTrendingUp />
-              +4.5%
-            </Badge>
-          </CardAction>
-        </CardHeader>
-        <CardFooter className="flex-col items-start gap-1.5 text-sm">
-          <div className="line-clamp-1 flex gap-2 font-medium">
-            Steady performance increase <IconTrendingUp className="size-4" />
-          </div>
-          <div className="text-muted-foreground">Meets growth projections</div>
-        </CardFooter>
-      </Card>
+      {cards.map(({ title, key }) => {
+        const data = summary?.[key];
+        const amount = data?.amount ?? 0;
+        const change = data?.change ?? 0;
+        const trendUp = change >= 0;
+        const ChangeIcon = trendUp ? IconTrendingUp : IconTrendingDown;
+        const formattedAmount = amount.toLocaleString("en-US", {
+          style: "currency",
+          currency: "USD",
+        });
+        return (
+          <Card key={key} className="@container/card">
+            <CardHeader>
+              <CardDescription>{title}</CardDescription>
+              <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
+                {formattedAmount}
+              </CardTitle>
+              <CardAction>
+                <Badge variant="outline">
+                  <ChangeIcon />
+                  {`${trendUp ? "+" : ""}${change}%`}
+                </Badge>
+              </CardAction>
+            </CardHeader>
+            <CardFooter className="flex-col items-start gap-1.5 text-sm">
+              <div className="line-clamp-1 flex gap-2 font-medium">
+                {trendUp ? "Trending up" : "Trending down"}
+                <ChangeIcon className="size-4" />
+              </div>
+              <div className="text-muted-foreground">Change since last period</div>
+            </CardFooter>
+          </Card>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- display dashboard summary metrics using dynamic summary card mapping
- pass fetched summary data from dashboard page to summary card component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898254902f48322aeb73066a71b50ff