### PR TITLE
feat: add revenue vs expense bar chart

### DIFF
--- a/src/app/admin-owner/dashboard/dashboard-content.tsx
+++ b/src/app/admin-owner/dashboard/dashboard-content.tsx
@@ -5,15 +5,37 @@
 import SummaryCard, {
   type DashboardSummary,
 } from "@/components/feature/dashboard/summary-card";
+import MultipleBarChart, {
+  type RevenueExpenseData,
+} from "@/components/shared/multiple-bar-chart";
+import { useState } from "react";
 
 export default function DashboardContent({
   summary,
+  chartData,
 }: {
   summary: DashboardSummary | null;
+  chartData: RevenueExpenseData[];
 }) {
+  const [period, setPeriod] = useState(6);
+  const filtered = Array.isArray(chartData)
+    ? chartData.slice(-period)
+    : [];
+
   return (
-    <section>
+    <section className="space-y-4">
       <SummaryCard summary={summary} />
+      <div className="flex justify-end">
+        <select
+          className="border rounded p-1 text-sm"
+          value={period}
+          onChange={(e) => setPeriod(Number(e.target.value))}
+        >
+          <option value={6}>6 Bulan Terakhir</option>
+          <option value={12}>12 Bulan Terakhir</option>
+        </select>
+      </div>
+      <MultipleBarChart data={filtered} />
     </section>
   );
 }

--- a/src/app/admin-owner/dashboard/page.tsx
+++ b/src/app/admin-owner/dashboard/page.tsx
@@ -1,15 +1,22 @@
 /** @format */
 
-import { getDashboardSummary } from "@/actions/dashboard";
+import { getDashboardSummary, getSalesChart } from "@/actions/dashboard";
 import DashboardContent from "./dashboard-content";
 
 export default async function DashboardPage() {
   let summary;
+  let chartData;
   try {
     summary = await getDashboardSummary();
   } catch {
     summary = null;
   }
 
-  return <DashboardContent summary={summary} />;
+  try {
+    chartData = await getSalesChart();
+  } catch {
+    chartData = [];
+  }
+
+  return <DashboardContent summary={summary} chartData={chartData} />;
 }

--- a/src/components/shared/multiple-bar-chart.tsx
+++ b/src/components/shared/multiple-bar-chart.tsx
@@ -1,0 +1,55 @@
+/** @format */
+
+"use client";
+
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+
+export interface RevenueExpenseData {
+  month: string;
+  income: number;
+  expense: number;
+}
+
+export default function MultipleBarChart({
+  data,
+}: {
+  data: RevenueExpenseData[];
+}) {
+  const chartConfig = {
+    income: {
+      label: "Pendapatan",
+      color: "hsl(var(--chart-1))",
+    },
+    expense: {
+      label: "Pengeluaran",
+      color: "hsl(var(--chart-2))",
+    },
+  };
+
+  return (
+    <ChartContainer config={chartConfig} className="w-full">
+      <BarChart data={data}>
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="month"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={10}
+        />
+        <YAxis />
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <ChartLegend content={<ChartLegendContent />} />
+        <Bar dataKey="income" fill="var(--color-income)" radius={4} />
+        <Bar dataKey="expense" fill="var(--color-expense)" radius={4} />
+      </BarChart>
+    </ChartContainer>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add MultipleBarChart component for income vs expense comparison
- fetch sales chart data for owner dashboard
- render period filter and bar chart on owner dashboard

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689834bfa14883229081ff9736cbf1a2