### PR TITLE
feat: fetch revenue vs expense chart for owner dashboard

### DIFF
--- a/src/actions/dashboard.ts
+++ b/src/actions/dashboard.ts
@@ -7,8 +7,9 @@ export async function getDashboardSummary() {
   return apiFetch(API_ENDPOINTS.dashboard.summary);
 }
 
-export async function getSalesChart() {
-  return apiFetch(API_ENDPOINTS.dashboard.salesChart);
+export async function getRevenueExpense() {
+  const data = await apiFetch(API_ENDPOINTS.dashboard.revenueExpense);
+  return data?.finance_chart ?? [];
 }
 
 export async function getTopProducts() {

--- a/src/app/admin-owner/dashboard/dashboard-content.tsx
+++ b/src/app/admin-owner/dashboard/dashboard-content.tsx
@@ -12,10 +12,10 @@ import { useState } from "react";
 
 export default function DashboardContent({
   summary,
-  chartData,
+  chartData = [],
 }: {
   summary: DashboardSummary | null;
-  chartData: RevenueExpenseData[];
+  chartData?: RevenueExpenseData[];
 }) {
   const [period, setPeriod] = useState(6);
   const filtered = Array.isArray(chartData)

--- a/src/app/admin-owner/dashboard/page.tsx
+++ b/src/app/admin-owner/dashboard/page.tsx
@@ -1,6 +1,6 @@
 /** @format */
 
-import { getDashboardSummary, getSalesChart } from "@/actions/dashboard";
+import { getDashboardSummary, getRevenueExpense } from "@/actions/dashboard";
 import DashboardContent from "./dashboard-content";
 
 export default async function DashboardPage() {
@@ -13,7 +13,7 @@ export default async function DashboardPage() {
   }
 
   try {
-    chartData = await getSalesChart();
+    chartData = await getRevenueExpense();
   } catch {
     chartData = [];
   }

--- a/src/components/shared/multiple-bar-chart.tsx
+++ b/src/components/shared/multiple-bar-chart.tsx
@@ -13,7 +13,7 @@ import {
 
 export interface RevenueExpenseData {
   month: string;
-  income: number;
+  revenue: number;
   expense: number;
 }
 
@@ -23,7 +23,7 @@ export default function MultipleBarChart({
   data: RevenueExpenseData[];
 }) {
   const chartConfig = {
-    income: {
+    revenue: {
       label: "Pendapatan",
       color: "hsl(var(--chart-1))",
     },
@@ -31,7 +31,7 @@ export default function MultipleBarChart({
       label: "Pengeluaran",
       color: "hsl(var(--chart-2))",
     },
-  };
+  } as const;
 
   return (
     <ChartContainer config={chartConfig} className="w-full">
@@ -46,7 +46,7 @@ export default function MultipleBarChart({
         <YAxis />
         <ChartTooltip content={<ChartTooltipContent />} />
         <ChartLegend content={<ChartLegendContent />} />
-        <Bar dataKey="income" fill="var(--color-income)" radius={4} />
+        <Bar dataKey="revenue" fill="var(--color-revenue)" radius={4} />
         <Bar dataKey="expense" fill="var(--color-expense)" radius={4} />
       </BarChart>
     </ChartContainer>

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -76,6 +76,7 @@ export const API_ENDPOINTS = {
   dashboard: {
     summary: '/dashboard/summary',
     salesChart: '/dashboard/sales-chart',
+    revenueExpense: '/dashboard/revenue-expense',
     topProducts: '/dashboard/top-products',
     notifications: '/dashboard/notifications',
   },


### PR DESCRIPTION
## Summary
- add revenue-expense dashboard endpoint
- show revenue vs expense chart on owner dashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68983ccc5aec832293dde0fcd644759b