### PR TITLE
feat: adapt dashboard summaries for client and owner

### DIFF
--- a/src/actions/dashboard.ts
+++ b/src/actions/dashboard.ts
@@ -3,20 +3,11 @@
 import { apiFetch } from './api';
 import { API_ENDPOINTS } from '@/constants/api';
 
-export async function getDashboardSummary() {
-  return apiFetch(API_ENDPOINTS.dashboard.summary);
-}
-
-export async function getRevenueExpense() {
-  const data = await apiFetch(API_ENDPOINTS.dashboard.revenueExpense);
-  return data?.finance_chart ?? [];
-}
-
-export async function getTopProducts() {
-  return apiFetch(API_ENDPOINTS.dashboard.topProducts);
-}
-
-export async function getDashboardNotifications() {
-  return apiFetch(API_ENDPOINTS.dashboard.notifications);
+export async function getDashboardSummary(type: 'client' | 'owner') {
+  const endpoint =
+    type === 'owner'
+      ? API_ENDPOINTS.dashboard.summaryOwner
+      : API_ENDPOINTS.dashboard.summaryClient;
+  return apiFetch(endpoint);
 }
 

--- a/src/app/admin-owner/dashboard/dashboard-content.tsx
+++ b/src/app/admin-owner/dashboard/dashboard-content.tsx
@@ -2,86 +2,67 @@
 
 "use client";
 
-import SummaryCard, {
-  type DashboardSummary,
-} from "@/components/feature/dashboard/summary-card";
-import { BarChartCard } from "@/components/shared/multiple-bar-chart";
-import { RevenueExpenseData } from "@/types/dashboard";
-
-import { useState } from "react";
-
-const chartSeries = [
-  { dataKey: "revenue", label: "Revenue" },
-  { dataKey: "expense", label: "Expense" },
-];
+import type { OwnerSummary } from "@/types/dashboard";
 
 export default function DashboardContent({
   summary,
-  chartData = [],
 }: {
-  summary: DashboardSummary | null;
-  chartData?: RevenueExpenseData[];
+  summary: OwnerSummary | null;
 }) {
-  const [period, setPeriod] = useState(6);
+  if (!summary) {
+    return <div className="p-4">Data tidak tersedia</div>;
+  }
+
+  const {
+    clients_per_tier = {},
+    open_tickets = 0,
+    most_active_client = "",
+    top_ticket_product = { name: "", tickets: 0 },
+    invoice_status = { lunas: 0, belum_lunas: 0 },
+    active_notifications = 0,
+  } = summary;
 
   return (
-    <section className="space-y-4">
-      <SummaryCard summary={summary} />
-      <div className="flex flex-col md:flex-row gap-4">
-        <div className="px-4 space-y-2 flex-1">
-          <div className="flex justify-end">
-            <select
-              className="border rounded p-1 text-sm"
-              value={period}
-              onChange={(e) => setPeriod(Number(e.target.value))}
-            >
-              <option value={6}>6 Bulan Terakhir</option>
-              <option value={12}>12 Bulan Terakhir</option>
-            </select>
-          </div>
-          <BarChartCard
-            title="Pendapatan vs Pengeluaran"
-            description="January - June 2024"
-            data={chartData}
-            xKey="month"
-            xTickFormatter={(v) => String(v).slice(0, 3)}
-            series={chartSeries}
-            tooltipIndicator="dashed"
-            footer={{
-              primary: <>Trending up by 5.2% this month</>,
-              secondary: "Showing total visitors for the last 6 months",
-              showTrendingIcon: true,
-            }}
-          />
+    <section className="space-y-4 p-4">
+      <h2 className="text-xl font-semibold">Ringkasan</h2>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="border rounded p-4">
+          <h3 className="font-medium mb-2">Clients per Tier</h3>
+          <ul className="list-disc list-inside">
+            {Object.entries(clients_per_tier).map(([tier, count]) => (
+              <li key={tier}>
+                {tier}: {count}
+              </li>
+            ))}
+          </ul>
         </div>
-
-        <div className="px-4 space-y-2 flex-1">
-          <div className="flex justify-end">
-            <select
-              className="border rounded p-1 text-sm"
-              value={period}
-              onChange={(e) => setPeriod(Number(e.target.value))}
-            >
-              <option value={6}>6 Bulan Terakhir</option>
-              <option value={12}>12 Bulan Terakhir</option>
-            </select>
-          </div>
-          <BarChartCard
-            title="Bar Chart - Multiple"
-            description="January - June 2024"
-            data={chartData}
-            xKey="month"
-            xTickFormatter={(v) => String(v).slice(0, 3)}
-            series={chartSeries}
-            tooltipIndicator="dashed"
-            footer={{
-              primary: <>Trending up by 5.2% this month</>,
-              secondary: "Showing total visitors for the last 6 months",
-              showTrendingIcon: true,
-            }}
-          />
+        <div className="border rounded p-4">
+          <h3 className="font-medium mb-2">Open Tickets</h3>
+          <p>{open_tickets}</p>
+        </div>
+        <div className="border rounded p-4">
+          <h3 className="font-medium mb-2">Most Active Client</h3>
+          <p>{most_active_client || "-"}</p>
+        </div>
+        <div className="border rounded p-4">
+          <h3 className="font-medium mb-2">Top Ticket Product</h3>
+          <p>
+            {top_ticket_product.name || "-"} ({top_ticket_product.tickets || 0})
+          </p>
+        </div>
+        <div className="border rounded p-4">
+          <h3 className="font-medium mb-2">Invoice Status</h3>
+          <ul className="list-disc list-inside">
+            <li>Lunas: {invoice_status.lunas || 0}</li>
+            <li>Belum Lunas: {invoice_status.belum_lunas || 0}</li>
+          </ul>
+        </div>
+        <div className="border rounded p-4">
+          <h3 className="font-medium mb-2">Active Notifications</h3>
+          <p>{active_notifications}</p>
         </div>
       </div>
     </section>
   );
 }
+

--- a/src/app/admin-owner/dashboard/page.tsx
+++ b/src/app/admin-owner/dashboard/page.tsx
@@ -1,22 +1,15 @@
 /** @format */
 
-import { getDashboardSummary, getRevenueExpense } from "@/actions/dashboard";
+import { getDashboardSummary } from "@/actions/dashboard";
 import DashboardContent from "./dashboard-content";
 
 export default async function DashboardPage() {
   let summary;
-  let chartData;
   try {
-    summary = await getDashboardSummary();
+    summary = await getDashboardSummary("owner");
   } catch {
     summary = null;
   }
 
-  try {
-    chartData = await getRevenueExpense();
-  } catch {
-    chartData = [];
-  }
-
-  return <DashboardContent summary={summary} chartData={chartData} />;
+  return <DashboardContent summary={summary} />;
 }

--- a/src/app/admin-user/dashboard/dashboard-content.tsx
+++ b/src/app/admin-user/dashboard/dashboard-content.tsx
@@ -1,0 +1,50 @@
+/** @format */
+
+"use client";
+
+import type { ClientSummary } from "@/types/dashboard";
+
+function formatCurrency(value: number) {
+  return value.toLocaleString("id-ID", {
+    style: "currency",
+    currency: "IDR",
+  });
+}
+
+export default function DashboardContent({
+  summary,
+}: {
+  summary: ClientSummary | null;
+}) {
+  const cards: { title: string; key: keyof ClientSummary }[] = [
+    { title: "Anggota Aktif", key: "active_members" },
+    { title: "Total Simpanan", key: "total_savings" },
+    { title: "Pinjaman Aktif", key: "active_loans" },
+    { title: "SHU Tahun Berjalan", key: "current_year_shu" },
+  ];
+
+  return (
+    <section className="space-y-4 p-4">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        {cards.map(({ title, key }) => {
+          const data = summary?.[key];
+          const amount = data?.amount ?? 0;
+          const change = data?.change ?? 0;
+          return (
+            <div key={key} className="border rounded p-4">
+              <h3 className="font-medium">{title}</h3>
+              <p className="text-lg font-semibold">
+                {formatCurrency(amount)}
+              </p>
+              <p className="text-sm text-muted-foreground">
+                {change >= 0 ? "+" : ""}
+                {change}%
+              </p>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+

--- a/src/app/admin-user/dashboard/page.tsx
+++ b/src/app/admin-user/dashboard/page.tsx
@@ -1,12 +1,12 @@
 /** @format */
 
 import { getDashboardSummary } from "@/actions/dashboard";
-import DashboardContent from "@/app/admin-owner/dashboard/dashboard-content";
+import DashboardContent from "./dashboard-content";
 
 export default async function DashboardPage() {
   let summary;
   try {
-    summary = await getDashboardSummary();
+    summary = await getDashboardSummary("client");
   } catch {
     summary = null;
   }

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -74,11 +74,8 @@ export const API_ENDPOINTS = {
     history: '/shu/history',
   },
   dashboard: {
-    summary: '/dashboard/summary',
-    salesChart: '/dashboard/sales-chart',
-    revenueExpense: '/dashboard/revenue-expense',
-    topProducts: '/dashboard/top-products',
-    notifications: '/dashboard/notifications',
+    summaryClient: '/dashboard/summary/client',
+    summaryOwner: '/dashboard/summary/owner',
   },
   reports: {
     profitLoss: '/reports/profit-loss',

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,7 +1,22 @@
 /** @format */
 
-export interface RevenueExpenseData {
-  month: string;
-  revenue: number;
-  expense: number;
+export type SummaryItem = {
+  amount: number;
+  change: number;
+};
+
+export interface ClientSummary {
+  active_members: SummaryItem;
+  total_savings: SummaryItem;
+  active_loans: SummaryItem;
+  current_year_shu: SummaryItem;
+}
+
+export interface OwnerSummary {
+  clients_per_tier: Record<string, number>;
+  open_tickets: number;
+  most_active_client: string;
+  top_ticket_product: { name: string; tickets: number };
+  invoice_status: { lunas: number; belum_lunas: number };
+  active_notifications: number;
 }


### PR DESCRIPTION
## Summary
- scope dashboard summaries to client and owner endpoints
- display owner metrics: tiered clients, tickets, invoices, notifications
- show client metrics: members, savings, loans and SHU

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689888cd39c883228f587a645111948c