### PR TITLE
feat: add role-based dashboard layouts

### DIFF
--- a/src/app/bumdes/layout.tsx
+++ b/src/app/bumdes/layout.tsx
@@ -1,0 +1,47 @@
+/** @format */
+
+'use client';
+
+import type { ReactNode } from 'react';
+import { usePathname } from 'next/navigation';
+import { ProtectedRoute } from '@/components/shared/protected-route';
+import { DashboardLayout } from '@/components/shared/dashboard-layout';
+import {
+  BarChart3,
+  Building,
+  MapPin,
+  Calendar,
+  FileText,
+  Settings,
+} from 'lucide-react';
+
+const navigation = [
+  { name: 'Dashboard', href: '/bumdes/dashboard', icon: <BarChart3 className="h-4 w-4" /> },
+  { name: 'Unit Usaha', href: '/bumdes/unit-usaha', icon: <Building className="h-4 w-4" /> },
+  { name: 'Aset Sewa', href: '/bumdes/aset-sewa', icon: <MapPin className="h-4 w-4" /> },
+  { name: 'Jadwal Sewa', href: '/bumdes/jadwal-sewa', icon: <Calendar className="h-4 w-4" /> },
+  { name: 'Laporan', href: '/bumdes/laporan', icon: <FileText className="h-4 w-4" /> },
+  { name: 'Pengaturan', href: '/bumdes/pengaturan', icon: <Settings className="h-4 w-4" /> },
+];
+
+const titleMap: Record<string, string> = {
+  '/bumdes/dashboard': 'Dashboard BUMDes',
+  '/bumdes/unit-usaha': 'Manajemen Unit Usaha',
+  '/bumdes/aset-sewa': 'Manajemen Aset Sewa',
+  '/bumdes/jadwal-sewa': 'Jadwal Sewa Aset',
+  '/bumdes/laporan': 'Laporan BUMDes',
+  '/bumdes/pengaturan': 'Pengaturan BUMDes',
+};
+
+export default function BumdesLayout({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const title = titleMap[pathname] ?? 'BUMDes';
+
+  return (
+    <ProtectedRoute requiredRole="bumdes">
+      <DashboardLayout title={title} navigation={navigation}>
+        {children}
+      </DashboardLayout>
+    </ProtectedRoute>
+  );
+}

--- a/src/app/koperasi/layout.tsx
+++ b/src/app/koperasi/layout.tsx
@@ -1,0 +1,58 @@
+/** @format */
+
+'use client';
+
+import type { ReactNode } from 'react';
+import { usePathname } from 'next/navigation';
+import { ProtectedRoute } from '@/components/shared/protected-route';
+import { DashboardLayout } from '@/components/shared/dashboard-layout';
+import {
+  BarChart3,
+  Users,
+  PiggyBank,
+  CreditCard,
+  TrendingUp,
+  Calendar,
+  Building,
+  Receipt,
+  FileText,
+  Settings,
+  MessageCircle,
+} from 'lucide-react';
+
+const navigation = [
+  { name: 'Dashboard', href: '/koperasi/dashboard', icon: <BarChart3 className="h-4 w-4" /> },
+  { name: 'Keanggotaan', href: '/koperasi/keanggotaan', icon: <Users className="h-4 w-4" /> },
+  { name: 'Simpanan', href: '/koperasi/simpanan', icon: <PiggyBank className="h-4 w-4" /> },
+  { name: 'Pinjaman', href: '/koperasi/pinjaman', icon: <CreditCard className="h-4 w-4" /> },
+  { name: 'SHU', href: '/koperasi/shu', icon: <TrendingUp className="h-4 w-4" /> },
+  { name: 'RAT', href: '/koperasi/rat', icon: <Calendar className="h-4 w-4" /> },
+  { name: 'Aset', href: '/koperasi/aset', icon: <Building className="h-4 w-4" /> },
+  { name: 'Transaksi', href: '/koperasi/transaksi', icon: <Receipt className="h-4 w-4" /> },
+  { name: 'Laporan', href: '/koperasi/laporan', icon: <FileText className="h-4 w-4" /> },
+  { name: 'Pengaturan', href: '/koperasi/pengaturan', icon: <Settings className="h-4 w-4" /> },
+  { name: 'Tagihan', href: '/koperasi/tagihan', icon: <Receipt className="h-4 w-4" /> },
+  { name: 'Chat Support', href: '/koperasi/chat-support', icon: <MessageCircle className="h-4 w-4" /> },
+];
+
+const titleMap: Record<string, string> = {
+  '/koperasi/dashboard': 'Dashboard Koperasi',
+  '/koperasi/keanggotaan': 'Manajemen Keanggotaan',
+  '/koperasi/simpanan': 'Manajemen Simpanan',
+  '/koperasi/pinjaman': 'Manajemen Pinjaman',
+  '/koperasi/shu': 'Sisa Hasil Usaha (SHU)',
+  '/koperasi/rat': 'Rapat Anggota Tahunan (RAT)',
+};
+
+export default function KoperasiLayout({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const title = titleMap[pathname] ?? 'Koperasi';
+
+  return (
+    <ProtectedRoute requiredRole="koperasi">
+      <DashboardLayout title={title} navigation={navigation}>
+        {children}
+      </DashboardLayout>
+    </ProtectedRoute>
+  );
+}

--- a/src/app/umkm/layout.tsx
+++ b/src/app/umkm/layout.tsx
@@ -1,0 +1,47 @@
+/** @format */
+
+'use client';
+
+import type { ReactNode } from 'react';
+import { usePathname } from 'next/navigation';
+import { ProtectedRoute } from '@/components/shared/protected-route';
+import { DashboardLayout } from '@/components/shared/dashboard-layout';
+import {
+  BarChart3,
+  Package,
+  Calculator,
+  ShoppingCart,
+  FileText,
+  Settings,
+} from 'lucide-react';
+
+const navigation = [
+  { name: 'Dashboard', href: '/umkm/dashboard', icon: <BarChart3 className="h-4 w-4" /> },
+  { name: 'Inventaris', href: '/umkm/inventaris', icon: <Package className="h-4 w-4" /> },
+  { name: 'Harga Bertingkat', href: '/umkm/harga-bertingkat', icon: <Calculator className="h-4 w-4" /> },
+  { name: 'POS', href: '/umkm/pos', icon: <ShoppingCart className="h-4 w-4" /> },
+  { name: 'Laporan', href: '/umkm/laporan', icon: <FileText className="h-4 w-4" /> },
+  { name: 'Pengaturan', href: '/umkm/pengaturan', icon: <Settings className="h-4 w-4" /> },
+];
+
+const titleMap: Record<string, string> = {
+  '/umkm/dashboard': 'Dashboard UMKM',
+  '/umkm/inventaris': 'Manajemen Inventaris',
+  '/umkm/harga-bertingkat': 'Harga Bertingkat',
+  '/umkm/pos': 'Point of Sale (POS)',
+  '/umkm/laporan': 'Laporan Penjualan',
+  '/umkm/pengaturan': 'Pengaturan UMKM',
+};
+
+export default function UmkmLayout({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const title = titleMap[pathname] ?? 'UMKM';
+
+  return (
+    <ProtectedRoute requiredRole="umkm">
+      <DashboardLayout title={title} navigation={navigation}>
+        {children}
+      </DashboardLayout>
+    </ProtectedRoute>
+  );
+}

--- a/src/app/vendor/layout.tsx
+++ b/src/app/vendor/layout.tsx
@@ -1,0 +1,49 @@
+/** @format */
+
+'use client';
+
+import type { ReactNode } from 'react';
+import { usePathname } from 'next/navigation';
+import { ProtectedRoute } from '@/components/shared/protected-route';
+import { DashboardLayout } from '@/components/shared/dashboard-layout';
+import {
+  BarChart3,
+  Package,
+  Users,
+  FileText,
+  Bell,
+  Ticket,
+} from 'lucide-react';
+
+const navigation = [
+  { name: 'Dashboard', href: '/vendor/dashboard', icon: <BarChart3 className="h-4 w-4" /> },
+  { name: 'Products', href: '/vendor/products', icon: <Package className="h-4 w-4" /> },
+  { name: 'Clients', href: '/vendor/clients', icon: <Users className="h-4 w-4" /> },
+  { name: 'Invoices', href: '/vendor/invoices', icon: <FileText className="h-4 w-4" /> },
+  { name: 'Users', href: '/vendor/users', icon: <Users className="h-4 w-4" /> },
+  { name: 'Notifications', href: '/vendor/notifications', icon: <Bell className="h-4 w-4" /> },
+  { name: 'Tickets', href: '/vendor/tickets', icon: <Ticket className="h-4 w-4" /> },
+];
+
+const titleMap: Record<string, string> = {
+  '/vendor/dashboard': 'Vendor Dashboard',
+  '/vendor/products': 'Products Management',
+  '/vendor/clients': 'Clients Management',
+  '/vendor/invoices': 'Invoices Management',
+  '/vendor/users': 'Users Management',
+  '/vendor/notifications': 'Notifications',
+  '/vendor/tickets': 'Support Tickets',
+};
+
+export default function VendorLayout({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const title = titleMap[pathname] ?? 'Vendor';
+
+  return (
+    <ProtectedRoute requiredRole="vendor">
+      <DashboardLayout title={title} navigation={navigation}>
+        {children}
+      </DashboardLayout>
+    </ProtectedRoute>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce dedicated layouts for bumdes, vendor, koperasi, and umkm sections

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689efcbb29a083229f6e91136d46ae1c