### PR TITLE
chore: remove redundant layout wrappers from route pages

### DIFF
--- a/src/app/bumdes/jadwal-sewa/page.tsx
+++ b/src/app/bumdes/jadwal-sewa/page.tsx
@@ -1,7 +1,5 @@
 /** @format */
 
-import { ProtectedRoute } from "@/components/shared/protected-route";
-import { DashboardLayout } from "@/components/shared/dashboard-layout";
 import {
   Card,
   CardContent,
@@ -13,11 +11,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import {
-  BarChart3,
-  Building,
   Calendar,
-  FileText,
-  Settings,
   Plus,
   Search,
   Edit,
@@ -27,35 +21,6 @@ import {
   User,
   Phone,
 } from "lucide-react";
-
-const bumdesNavigation = [
-  {
-    name: "Dashboard",
-    href: "/dashboard",
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    name: "Unit Usaha",
-    href: "/unit-usaha",
-    icon: <Building className="h-4 w-4" />,
-  },
-  {
-    name: "Aset Sewa",
-    href: "/aset-sewa",
-    icon: <MapPin className="h-4 w-4" />,
-  },
-  {
-    name: "Jadwal Sewa",
-    href: "/jadwal-sewa",
-    icon: <Calendar className="h-4 w-4" />,
-  },
-  { name: "Laporan", href: "/laporan", icon: <FileText className="h-4 w-4" /> },
-  {
-    name: "Pengaturan",
-    href: "/pengaturan",
-    icon: <Settings className="h-4 w-4" />,
-  },
-];
 
 const bookings = [
   {
@@ -118,207 +83,193 @@ const bookings = [
 
 export default function JadwalSewaPage() {
   return (
-    <ProtectedRoute requiredRole="bumdes">
-      <DashboardLayout title="Jadwal Sewa Aset" navigation={bumdesNavigation}>
-        <div className="space-y-6">
-          {/* Header */}
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-2xl font-bold">Jadwal Sewa</h2>
-              <p className="text-muted-foreground">
-                Kelola booking dan jadwal sewa aset
-              </p>
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold">Jadwal Sewa</h2>
+          <p className="text-muted-foreground">
+            Kelola booking dan jadwal sewa aset
+          </p>
+        </div>
+        <Button>
+          <Plus className="h-4 w-4 mr-2" />
+          Tambah Booking
+        </Button>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">
+              Booking Hari Ini
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">3</div>
+            <p className="text-xs text-muted-foreground">Jadwal aktif</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">
+              Booking Minggu Ini
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">12</div>
+            <p className="text-xs text-muted-foreground">+3 dari minggu lalu</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">
+              Menunggu Konfirmasi
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">5</div>
+            <p className="text-xs text-muted-foreground">Perlu tindak lanjut</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">
+              Pendapatan Minggu Ini
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">Rp 3.2M</div>
+            <p className="text-xs text-muted-foreground">
+              +18% dari minggu lalu
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Search and Filters */}
+      <Card>
+        <CardContent className="pt-6">
+          <div className="flex items-center gap-4">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input placeholder="Cari booking..." className="pl-10" />
             </div>
-            <Button>
-              <Plus className="h-4 w-4 mr-2" />
-              Tambah Booking
-            </Button>
+            <Button variant="outline">Filter Tanggal</Button>
+            <Button variant="outline">Filter Status</Button>
           </div>
+        </CardContent>
+      </Card>
 
-          {/* Stats */}
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Booking Hari Ini
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">3</div>
-                <p className="text-xs text-muted-foreground">Jadwal aktif</p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Booking Minggu Ini
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">12</div>
-                <p className="text-xs text-muted-foreground">
-                  +3 dari minggu lalu
-                </p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Menunggu Konfirmasi
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">5</div>
-                <p className="text-xs text-muted-foreground">
-                  Perlu tindak lanjut
-                </p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Pendapatan Minggu Ini
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">Rp 3.2M</div>
-                <p className="text-xs text-muted-foreground">
-                  +18% dari minggu lalu
-                </p>
-              </CardContent>
-            </Card>
-          </div>
-
-          {/* Search and Filters */}
-          <Card>
-            <CardContent className="pt-6">
-              <div className="flex items-center gap-4">
-                <div className="relative flex-1">
-                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                  <Input placeholder="Cari booking..." className="pl-10" />
-                </div>
-                <Button variant="outline">Filter Tanggal</Button>
-                <Button variant="outline">Filter Status</Button>
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Bookings List */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Daftar Booking</CardTitle>
-              <CardDescription>
-                Jadwal sewa aset yang akan datang
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                {bookings.map((booking) => (
-                  <div key={booking.id} className="p-4 border rounded-lg">
-                    <div className="flex items-start justify-between mb-4">
-                      <div className="flex items-start gap-4">
-                        <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
-                          <MapPin className="h-6 w-6" />
-                        </div>
-                        <div>
-                          <h3 className="font-medium">{booking.asset}</h3>
-                          <p className="text-sm text-muted-foreground">
-                            {booking.purpose}
-                          </p>
-                          <div className="flex items-center gap-4 mt-2 text-sm text-muted-foreground">
-                            <span className="flex items-center gap-1">
-                              <Calendar className="h-3 w-3" />
-                              {booking.date}
-                            </span>
-                            <span className="flex items-center gap-1">
-                              <Clock className="h-3 w-3" />
-                              {booking.startTime} - {booking.endTime}
-                            </span>
-                            <span>({booking.duration})</span>
-                          </div>
-                        </div>
-                      </div>
-
-                      <div className="flex items-center gap-2">
-                        <Badge
-                          variant={
-                            booking.status === "confirmed"
-                              ? "default"
-                              : booking.status === "pending"
-                              ? "secondary"
-                              : "destructive"
-                          }
-                        >
-                          {booking.status}
-                        </Badge>
-                        <Badge
-                          variant={
-                            booking.paymentStatus === "paid"
-                              ? "default"
-                              : booking.paymentStatus === "partial"
-                              ? "secondary"
-                              : "destructive"
-                          }
-                        >
-                          {booking.paymentStatus === "paid"
-                            ? "Lunas"
-                            : booking.paymentStatus === "partial"
-                            ? "Sebagian"
-                            : "Belum Bayar"}
-                        </Badge>
-                      </div>
+      {/* Bookings List */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Daftar Booking</CardTitle>
+          <CardDescription>Jadwal sewa aset yang akan datang</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {bookings.map((booking) => (
+              <div key={booking.id} className="p-4 border rounded-lg">
+                <div className="flex items-start justify-between mb-4">
+                  <div className="flex items-start gap-4">
+                    <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
+                      <MapPin className="h-6 w-6" />
                     </div>
-
-                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
-                      <div>
-                        <p className="text-sm text-muted-foreground">Penyewa</p>
-                        <div className="flex items-center gap-1">
-                          <User className="h-4 w-4" />
-                          <span className="font-medium">{booking.renter}</span>
-                        </div>
+                    <div>
+                      <h3 className="font-medium">{booking.asset}</h3>
+                      <p className="text-sm text-muted-foreground">
+                        {booking.purpose}
+                      </p>
+                      <div className="flex items-center gap-4 mt-2 text-sm text-muted-foreground">
+                        <span className="flex items-center gap-1">
+                          <Calendar className="h-3 w-3" />
+                          {booking.date}
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <Clock className="h-3 w-3" />
+                          {booking.startTime} - {booking.endTime}
+                        </span>
+                        <span>({booking.duration})</span>
                       </div>
-                      <div>
-                        <p className="text-sm text-muted-foreground">Kontak</p>
-                        <div className="flex items-center gap-1">
-                          <Phone className="h-4 w-4" />
-                          <span className="font-medium">{booking.contact}</span>
-                        </div>
-                      </div>
-                      <div>
-                        <p className="text-sm text-muted-foreground">
-                          Total Biaya
-                        </p>
-                        <p className="font-bold text-lg">
-                          {booking.totalPrice}
-                        </p>
-                      </div>
-                    </div>
-
-                    <div className="flex gap-2">
-                      <Button variant="outline" size="sm">
-                        <Eye className="h-4 w-4 mr-2" />
-                        Detail
-                      </Button>
-                      <Button variant="outline" size="sm">
-                        <Edit className="h-4 w-4 mr-2" />
-                        Edit
-                      </Button>
-                      {booking.status === "pending" && (
-                        <Button size="sm">Konfirmasi</Button>
-                      )}
-                      {booking.paymentStatus !== "paid" && (
-                        <Button variant="outline" size="sm">
-                          Tagih Pembayaran
-                        </Button>
-                      )}
                     </div>
                   </div>
-                ))}
+
+                  <div className="flex items-center gap-2">
+                    <Badge
+                      variant={
+                        booking.status === "confirmed"
+                          ? "default"
+                          : booking.status === "pending"
+                            ? "secondary"
+                            : "destructive"
+                      }
+                    >
+                      {booking.status}
+                    </Badge>
+                    <Badge
+                      variant={
+                        booking.paymentStatus === "paid"
+                          ? "default"
+                          : booking.paymentStatus === "partial"
+                            ? "secondary"
+                            : "destructive"
+                      }
+                    >
+                      {booking.paymentStatus === "paid"
+                        ? "Lunas"
+                        : booking.paymentStatus === "partial"
+                          ? "Sebagian"
+                          : "Belum Bayar"}
+                    </Badge>
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+                  <div>
+                    <p className="text-sm text-muted-foreground">Penyewa</p>
+                    <div className="flex items-center gap-1">
+                      <User className="h-4 w-4" />
+                      <span className="font-medium">{booking.renter}</span>
+                    </div>
+                  </div>
+                  <div>
+                    <p className="text-sm text-muted-foreground">Kontak</p>
+                    <div className="flex items-center gap-1">
+                      <Phone className="h-4 w-4" />
+                      <span className="font-medium">{booking.contact}</span>
+                    </div>
+                  </div>
+                  <div>
+                    <p className="text-sm text-muted-foreground">Total Biaya</p>
+                    <p className="font-bold text-lg">{booking.totalPrice}</p>
+                  </div>
+                </div>
+
+                <div className="flex gap-2">
+                  <Button variant="outline" size="sm">
+                    <Eye className="h-4 w-4 mr-2" />
+                    Detail
+                  </Button>
+                  <Button variant="outline" size="sm">
+                    <Edit className="h-4 w-4 mr-2" />
+                    Edit
+                  </Button>
+                  {booking.status === "pending" && (
+                    <Button size="sm">Konfirmasi</Button>
+                  )}
+                  {booking.paymentStatus !== "paid" && (
+                    <Button variant="outline" size="sm">
+                      Tagih Pembayaran
+                    </Button>
+                  )}
+                </div>
               </div>
-            </CardContent>
-          </Card>
-        </div>
-      </DashboardLayout>
-    </ProtectedRoute>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/src/app/bumdes/laporan/page.tsx
+++ b/src/app/bumdes/laporan/page.tsx
@@ -1,7 +1,5 @@
 /** @format */
 
-import { ProtectedRoute } from "@/components/shared/protected-route";
-import { DashboardLayout } from "@/components/shared/dashboard-layout";
 import {
   Card,
   CardContent,
@@ -14,9 +12,6 @@ import { Badge } from "@/components/ui/badge";
 import {
   BarChart3,
   Building,
-  Calendar,
-  FileText,
-  Settings,
   Download,
   TrendingUp,
   TrendingDown,
@@ -24,35 +19,6 @@ import {
   DollarSign,
   Users,
 } from "lucide-react";
-
-const bumdesNavigation = [
-  {
-    name: "Dashboard",
-    href: "/dashboard",
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    name: "Unit Usaha",
-    href: "/unit-usaha",
-    icon: <Building className="h-4 w-4" />,
-  },
-  {
-    name: "Aset Sewa",
-    href: "/aset-sewa",
-    icon: <MapPin className="h-4 w-4" />,
-  },
-  {
-    name: "Jadwal Sewa",
-    href: "/jadwal-sewa",
-    icon: <Calendar className="h-4 w-4" />,
-  },
-  { name: "Laporan", href: "/laporan", icon: <FileText className="h-4 w-4" /> },
-  {
-    name: "Pengaturan",
-    href: "/pengaturan",
-    icon: <Settings className="h-4 w-4" />,
-  },
-];
 
 const performanceData = [
   {
@@ -135,235 +101,231 @@ const assetUtilization = [
 
 export default function LaporanPage() {
   return (
-    <ProtectedRoute requiredRole="bumdes">
-      <DashboardLayout title="Laporan BUMDes" navigation={bumdesNavigation}>
-        <div className="space-y-6">
-          {/* Header */}
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-2xl font-bold">Laporan</h2>
-              <p className="text-muted-foreground">
-                Analisis kinerja dan dampak BUMDes
-              </p>
-            </div>
-            <div className="flex gap-2">
-              <Button variant="outline">
-                <Download className="h-4 w-4 mr-2" />
-                Export PDF
-              </Button>
-              <Button variant="outline">
-                <Download className="h-4 w-4 mr-2" />
-                Export Excel
-              </Button>
-            </div>
-          </div>
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold">Laporan</h2>
+          <p className="text-muted-foreground">
+            Analisis kinerja dan dampak BUMDes
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline">
+            <Download className="h-4 w-4 mr-2" />
+            Export PDF
+          </Button>
+          <Button variant="outline">
+            <Download className="h-4 w-4 mr-2" />
+            Export Excel
+          </Button>
+        </div>
+      </div>
 
-          {/* Performance Overview */}
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            {performanceData.map((data) => (
-              <Card key={data.period}>
-                <CardHeader>
-                  <CardTitle className="text-sm font-medium">
-                    {data.period}
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="text-2xl font-bold">{data.revenue}</div>
-                  <div className="flex items-center gap-1 text-xs mt-2">
-                    {data.trend === "up" ? (
-                      <TrendingUp className="h-3 w-3 text-green-500" />
-                    ) : (
-                      <TrendingDown className="h-3 w-3 text-red-500" />
-                    )}
-                    <span
-                      className={
-                        data.trend === "up" ? "text-green-500" : "text-red-500"
-                      }
-                    >
-                      {data.growth}
-                    </span>
-                    <span className="text-muted-foreground">
-                      dari periode sebelumnya
-                    </span>
+      {/* Performance Overview */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {performanceData.map((data) => (
+          <Card key={data.period}>
+            <CardHeader>
+              <CardTitle className="text-sm font-medium">
+                {data.period}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{data.revenue}</div>
+              <div className="flex items-center gap-1 text-xs mt-2">
+                {data.trend === "up" ? (
+                  <TrendingUp className="h-3 w-3 text-green-500" />
+                ) : (
+                  <TrendingDown className="h-3 w-3 text-red-500" />
+                )}
+                <span
+                  className={
+                    data.trend === "up" ? "text-green-500" : "text-red-500"
+                  }
+                >
+                  {data.growth}
+                </span>
+                <span className="text-muted-foreground">
+                  dari periode sebelumnya
+                </span>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Charts Section */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Tren Pendapatan</CardTitle>
+            <CardDescription>Pendapatan 12 bulan terakhir</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="h-64 flex items-center justify-center bg-muted rounded-lg">
+              <div className="text-center">
+                <BarChart3 className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
+                <p className="text-muted-foreground">Grafik Pendapatan</p>
+                <p className="text-sm text-muted-foreground">
+                  Data visualisasi akan ditampilkan di sini
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Dampak Sosial</CardTitle>
+            <CardDescription>
+              Kontribusi BUMDes untuk masyarakat
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <Users className="h-4 w-4" />
+                  <span>Warga Terlibat</span>
+                </div>
+                <span className="font-bold">245 orang</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <DollarSign className="h-4 w-4" />
+                  <span>Dana Desa Terkumpul</span>
+                </div>
+                <span className="font-bold">Rp 25M</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <Building className="h-4 w-4" />
+                  <span>Program Pemberdayaan</span>
+                </div>
+                <span className="font-bold">15 program</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <TrendingUp className="h-4 w-4" />
+                  <span>Peningkatan Ekonomi</span>
+                </div>
+                <span className="font-bold text-green-600">+32%</span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Unit Performance */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Kinerja Unit Usaha</CardTitle>
+          <CardDescription>
+            Pendapatan dan kontribusi setiap unit usaha
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {unitPerformance.map((unit) => (
+              <div
+                key={unit.name}
+                className="flex items-center justify-between p-4 border rounded-lg"
+              >
+                <div className="flex items-center gap-4">
+                  <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
+                    <Building className="h-6 w-6" />
                   </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-
-          {/* Charts Section */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <Card>
-              <CardHeader>
-                <CardTitle>Tren Pendapatan</CardTitle>
-                <CardDescription>Pendapatan 12 bulan terakhir</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="h-64 flex items-center justify-center bg-muted rounded-lg">
-                  <div className="text-center">
-                    <BarChart3 className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
-                    <p className="text-muted-foreground">Grafik Pendapatan</p>
+                  <div>
+                    <h3 className="font-medium">{unit.name}</h3>
                     <p className="text-sm text-muted-foreground">
-                      Data visualisasi akan ditampilkan di sini
+                      Kontribusi: {unit.contribution}
                     </p>
                   </div>
                 </div>
-              </CardContent>
-            </Card>
 
-            <Card>
-              <CardHeader>
-                <CardTitle>Dampak Sosial</CardTitle>
-                <CardDescription>
-                  Kontribusi BUMDes untuk masyarakat
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-4">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                      <Users className="h-4 w-4" />
-                      <span>Warga Terlibat</span>
+                <div className="flex items-center gap-6">
+                  <div className="text-right">
+                    <p className="font-medium">{unit.revenue}</p>
+                    <div className="flex items-center gap-1">
+                      {unit.trend === "up" ? (
+                        <TrendingUp className="h-3 w-3 text-green-500" />
+                      ) : (
+                        <TrendingDown className="h-3 w-3 text-red-500" />
+                      )}
+                      <span
+                        className={
+                          unit.trend === "up"
+                            ? "text-green-500"
+                            : "text-red-500"
+                        }
+                      >
+                        {unit.growth}
+                      </span>
                     </div>
-                    <span className="font-bold">245 orang</span>
                   </div>
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                      <DollarSign className="h-4 w-4" />
-                      <span>Dana Desa Terkumpul</span>
-                    </div>
-                    <span className="font-bold">Rp 25M</span>
+
+                  <Badge
+                    variant={unit.trend === "up" ? "default" : "secondary"}
+                  >
+                    {unit.trend === "up" ? "Naik" : "Turun"}
+                  </Badge>
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Asset Utilization */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Utilisasi Aset Sewa</CardTitle>
+          <CardDescription>
+            Tingkat penggunaan dan pendapatan aset
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {assetUtilization.map((asset) => (
+              <div
+                key={asset.asset}
+                className="flex items-center justify-between p-4 border rounded-lg"
+              >
+                <div className="flex items-center gap-4">
+                  <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
+                    <MapPin className="h-6 w-6" />
                   </div>
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                      <Building className="h-4 w-4" />
-                      <span>Program Pemberdayaan</span>
-                    </div>
-                    <span className="font-bold">15 program</span>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                      <TrendingUp className="h-4 w-4" />
-                      <span>Peningkatan Ekonomi</span>
-                    </div>
-                    <span className="font-bold text-green-600">+32%</span>
+                  <div>
+                    <h3 className="font-medium">{asset.asset}</h3>
+                    <p className="text-sm text-muted-foreground">
+                      {asset.bookings} booking bulan ini
+                    </p>
                   </div>
                 </div>
-              </CardContent>
-            </Card>
+
+                <div className="flex items-center gap-6">
+                  <div className="text-right">
+                    <p className="font-medium">{asset.revenue}</p>
+                    <p className="text-sm text-muted-foreground">
+                      Utilisasi: {asset.utilization}
+                    </p>
+                  </div>
+
+                  <div className="w-20">
+                    <div className="w-full bg-muted rounded-full h-2">
+                      <div
+                        className="bg-primary h-2 rounded-full"
+                        style={{ width: asset.utilization }}
+                      ></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
           </div>
-
-          {/* Unit Performance */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Kinerja Unit Usaha</CardTitle>
-              <CardDescription>
-                Pendapatan dan kontribusi setiap unit usaha
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                {unitPerformance.map((unit) => (
-                  <div
-                    key={unit.name}
-                    className="flex items-center justify-between p-4 border rounded-lg"
-                  >
-                    <div className="flex items-center gap-4">
-                      <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
-                        <Building className="h-6 w-6" />
-                      </div>
-                      <div>
-                        <h3 className="font-medium">{unit.name}</h3>
-                        <p className="text-sm text-muted-foreground">
-                          Kontribusi: {unit.contribution}
-                        </p>
-                      </div>
-                    </div>
-
-                    <div className="flex items-center gap-6">
-                      <div className="text-right">
-                        <p className="font-medium">{unit.revenue}</p>
-                        <div className="flex items-center gap-1">
-                          {unit.trend === "up" ? (
-                            <TrendingUp className="h-3 w-3 text-green-500" />
-                          ) : (
-                            <TrendingDown className="h-3 w-3 text-red-500" />
-                          )}
-                          <span
-                            className={
-                              unit.trend === "up"
-                                ? "text-green-500"
-                                : "text-red-500"
-                            }
-                          >
-                            {unit.growth}
-                          </span>
-                        </div>
-                      </div>
-
-                      <Badge
-                        variant={unit.trend === "up" ? "default" : "secondary"}
-                      >
-                        {unit.trend === "up" ? "Naik" : "Turun"}
-                      </Badge>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Asset Utilization */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Utilisasi Aset Sewa</CardTitle>
-              <CardDescription>
-                Tingkat penggunaan dan pendapatan aset
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                {assetUtilization.map((asset) => (
-                  <div
-                    key={asset.asset}
-                    className="flex items-center justify-between p-4 border rounded-lg"
-                  >
-                    <div className="flex items-center gap-4">
-                      <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
-                        <MapPin className="h-6 w-6" />
-                      </div>
-                      <div>
-                        <h3 className="font-medium">{asset.asset}</h3>
-                        <p className="text-sm text-muted-foreground">
-                          {asset.bookings} booking bulan ini
-                        </p>
-                      </div>
-                    </div>
-
-                    <div className="flex items-center gap-6">
-                      <div className="text-right">
-                        <p className="font-medium">{asset.revenue}</p>
-                        <p className="text-sm text-muted-foreground">
-                          Utilisasi: {asset.utilization}
-                        </p>
-                      </div>
-
-                      <div className="w-20">
-                        <div className="w-full bg-muted rounded-full h-2">
-                          <div
-                            className="bg-primary h-2 rounded-full"
-                            style={{ width: asset.utilization }}
-                          ></div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-      </DashboardLayout>
-    </ProtectedRoute>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/src/app/bumdes/pengaturan/page.tsx
+++ b/src/app/bumdes/pengaturan/page.tsx
@@ -1,7 +1,5 @@
 /** @format */
 
-import { ProtectedRoute } from "@/components/shared/protected-route";
-import { DashboardLayout } from "@/components/shared/dashboard-layout";
 import {
   Card,
   CardContent,
@@ -14,306 +12,244 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
-import {
-  BarChart3,
-  Building,
-  Calendar,
-  FileText,
-  Settings,
-  MapPin,
-  Bell,
-  Shield,
-  Users,
-  DollarSign,
-} from "lucide-react";
-
-const bumdesNavigation = [
-  {
-    name: "Dashboard",
-    href: "/dashboard",
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    name: "Unit Usaha",
-    href: "/unit-usaha",
-    icon: <Building className="h-4 w-4" />,
-  },
-  {
-    name: "Aset Sewa",
-    href: "/aset-sewa",
-    icon: <MapPin className="h-4 w-4" />,
-  },
-  {
-    name: "Jadwal Sewa",
-    href: "/jadwal-sewa",
-    icon: <Calendar className="h-4 w-4" />,
-  },
-  { name: "Laporan", href: "/laporan", icon: <FileText className="h-4 w-4" /> },
-  {
-    name: "Pengaturan",
-    href: "/pengaturan",
-    icon: <Settings className="h-4 w-4" />,
-  },
-];
+import { Building, Bell, Shield, Users, DollarSign } from "lucide-react";
 
 export default function PengaturanPage() {
   return (
-    <ProtectedRoute requiredRole="bumdes">
-      <DashboardLayout title="Pengaturan BUMDes" navigation={bumdesNavigation}>
-        <div className="space-y-6">
-          {/* Header */}
-          <div>
-            <h2 className="text-2xl font-bold">Pengaturan</h2>
-            <p className="text-muted-foreground">
-              Kelola konfigurasi dan preferensi BUMDes
-            </p>
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h2 className="text-2xl font-bold">Pengaturan</h2>
+        <p className="text-muted-foreground">
+          Kelola konfigurasi dan preferensi BUMDes
+        </p>
+      </div>
+
+      {/* BUMDes Information */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Building className="h-5 w-5" />
+            <CardTitle>Informasi BUMDes</CardTitle>
           </div>
+          <CardDescription>Data dasar Badan Usaha Milik Desa</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="bumdes-name">Nama BUMDes</Label>
+              <Input id="bumdes-name" defaultValue="BUMDes Maju Bersama" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="village-name">Nama Desa</Label>
+              <Input id="village-name" defaultValue="Desa Maju Sejahtera" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="director-name">Nama Direktur</Label>
+              <Input id="director-name" defaultValue="Budi Santoso" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="phone">Nomor Telepon</Label>
+              <Input id="phone" defaultValue="+62 812-3456-7890" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                defaultValue="info@bumdes-majubersama.id"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="established">Tahun Berdiri</Label>
+              <Input id="established" defaultValue="2020" />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="address">Alamat Lengkap</Label>
+            <Textarea
+              id="address"
+              defaultValue="Jl. Desa Raya No. 123, Desa Maju Sejahtera, Kecamatan Maju, Kabupaten Sejahtera, Provinsi Jawa Tengah"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="vision">Visi BUMDes</Label>
+            <Textarea
+              id="vision"
+              defaultValue="Menjadi BUMDes yang mandiri, berkelanjutan, dan memberikan manfaat maksimal bagi kesejahteraan masyarakat desa"
+            />
+          </div>
+          <Button>Simpan Perubahan</Button>
+        </CardContent>
+      </Card>
 
-          {/* BUMDes Information */}
-          <Card>
-            <CardHeader>
-              <div className="flex items-center gap-2">
-                <Building className="h-5 w-5" />
-                <CardTitle>Informasi BUMDes</CardTitle>
-              </div>
-              <CardDescription>
-                Data dasar Badan Usaha Milik Desa
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="bumdes-name">Nama BUMDes</Label>
-                  <Input id="bumdes-name" defaultValue="BUMDes Maju Bersama" />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="village-name">Nama Desa</Label>
-                  <Input id="village-name" defaultValue="Desa Maju Sejahtera" />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="director-name">Nama Direktur</Label>
-                  <Input id="director-name" defaultValue="Budi Santoso" />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="phone">Nomor Telepon</Label>
-                  <Input id="phone" defaultValue="+62 812-3456-7890" />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="email">Email</Label>
-                  <Input
-                    id="email"
-                    type="email"
-                    defaultValue="info@bumdes-majubersama.id"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="established">Tahun Berdiri</Label>
-                  <Input id="established" defaultValue="2020" />
-                </div>
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="address">Alamat Lengkap</Label>
-                <Textarea
-                  id="address"
-                  defaultValue="Jl. Desa Raya No. 123, Desa Maju Sejahtera, Kecamatan Maju, Kabupaten Sejahtera, Provinsi Jawa Tengah"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="vision">Visi BUMDes</Label>
-                <Textarea
-                  id="vision"
-                  defaultValue="Menjadi BUMDes yang mandiri, berkelanjutan, dan memberikan manfaat maksimal bagi kesejahteraan masyarakat desa"
-                />
-              </div>
-              <Button>Simpan Perubahan</Button>
-            </CardContent>
-          </Card>
+      {/* Business Settings */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <DollarSign className="h-5 w-5" />
+            <CardTitle>Pengaturan Bisnis</CardTitle>
+          </div>
+          <CardDescription>Konfigurasi operasional BUMDes</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <Label htmlFor="auto-approval">Persetujuan Otomatis Sewa</Label>
+              <p className="text-sm text-muted-foreground">
+                Setujui booking aset secara otomatis
+              </p>
+            </div>
+            <Switch id="auto-approval" />
+          </div>
+          <div className="flex items-center justify-between">
+            <div>
+              <Label htmlFor="advance-payment">Pembayaran Uang Muka</Label>
+              <p className="text-sm text-muted-foreground">
+                Wajibkan uang muka untuk booking
+              </p>
+            </div>
+            <Switch id="advance-payment" defaultChecked />
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="advance-percentage">
+                Persentase Uang Muka (%)
+              </Label>
+              <Input id="advance-percentage" type="number" defaultValue="30" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="cancellation-fee">Biaya Pembatalan (%)</Label>
+              <Input id="cancellation-fee" type="number" defaultValue="10" />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="booking-limit">Batas Waktu Booking (hari)</Label>
+            <Input id="booking-limit" type="number" defaultValue="7" />
+          </div>
+        </CardContent>
+      </Card>
 
-          {/* Business Settings */}
-          <Card>
-            <CardHeader>
-              <div className="flex items-center gap-2">
-                <DollarSign className="h-5 w-5" />
-                <CardTitle>Pengaturan Bisnis</CardTitle>
-              </div>
-              <CardDescription>Konfigurasi operasional BUMDes</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label htmlFor="auto-approval">
-                    Persetujuan Otomatis Sewa
-                  </Label>
-                  <p className="text-sm text-muted-foreground">
-                    Setujui booking aset secara otomatis
-                  </p>
-                </div>
-                <Switch id="auto-approval" />
-              </div>
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label htmlFor="advance-payment">Pembayaran Uang Muka</Label>
-                  <p className="text-sm text-muted-foreground">
-                    Wajibkan uang muka untuk booking
-                  </p>
-                </div>
-                <Switch id="advance-payment" defaultChecked />
-              </div>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="advance-percentage">
-                    Persentase Uang Muka (%)
-                  </Label>
-                  <Input
-                    id="advance-percentage"
-                    type="number"
-                    defaultValue="30"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="cancellation-fee">Biaya Pembatalan (%)</Label>
-                  <Input
-                    id="cancellation-fee"
-                    type="number"
-                    defaultValue="10"
-                  />
-                </div>
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="booking-limit">
-                  Batas Waktu Booking (hari)
-                </Label>
-                <Input id="booking-limit" type="number" defaultValue="7" />
-              </div>
-            </CardContent>
-          </Card>
+      {/* Notification Settings */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Bell className="h-5 w-5" />
+            <CardTitle>Notifikasi</CardTitle>
+          </div>
+          <CardDescription>Atur preferensi notifikasi</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <Label htmlFor="booking-notification">
+                Notifikasi Booking Baru
+              </Label>
+              <p className="text-sm text-muted-foreground">
+                Terima notifikasi untuk booking baru
+              </p>
+            </div>
+            <Switch id="booking-notification" defaultChecked />
+          </div>
+          <div className="flex items-center justify-between">
+            <div>
+              <Label htmlFor="payment-reminder">Pengingat Pembayaran</Label>
+              <p className="text-sm text-muted-foreground">
+                Kirim pengingat untuk pembayaran tertunggak
+              </p>
+            </div>
+            <Switch id="payment-reminder" defaultChecked />
+          </div>
+          <div className="flex items-center justify-between">
+            <div>
+              <Label htmlFor="monthly-report">Laporan Bulanan</Label>
+              <p className="text-sm text-muted-foreground">
+                Kirim ringkasan kinerja bulanan
+              </p>
+            </div>
+            <Switch id="monthly-report" defaultChecked />
+          </div>
+          <div className="flex items-center justify-between">
+            <div>
+              <Label htmlFor="maintenance-alert">Peringatan Maintenance</Label>
+              <p className="text-sm text-muted-foreground">
+                Notifikasi jadwal maintenance aset
+              </p>
+            </div>
+            <Switch id="maintenance-alert" />
+          </div>
+        </CardContent>
+      </Card>
 
-          {/* Notification Settings */}
-          <Card>
-            <CardHeader>
-              <div className="flex items-center gap-2">
-                <Bell className="h-5 w-5" />
-                <CardTitle>Notifikasi</CardTitle>
-              </div>
-              <CardDescription>Atur preferensi notifikasi</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label htmlFor="booking-notification">
-                    Notifikasi Booking Baru
-                  </Label>
-                  <p className="text-sm text-muted-foreground">
-                    Terima notifikasi untuk booking baru
-                  </p>
-                </div>
-                <Switch id="booking-notification" defaultChecked />
-              </div>
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label htmlFor="payment-reminder">Pengingat Pembayaran</Label>
-                  <p className="text-sm text-muted-foreground">
-                    Kirim pengingat untuk pembayaran tertunggak
-                  </p>
-                </div>
-                <Switch id="payment-reminder" defaultChecked />
-              </div>
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label htmlFor="monthly-report">Laporan Bulanan</Label>
-                  <p className="text-sm text-muted-foreground">
-                    Kirim ringkasan kinerja bulanan
-                  </p>
-                </div>
-                <Switch id="monthly-report" defaultChecked />
-              </div>
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label htmlFor="maintenance-alert">
-                    Peringatan Maintenance
-                  </Label>
-                  <p className="text-sm text-muted-foreground">
-                    Notifikasi jadwal maintenance aset
-                  </p>
-                </div>
-                <Switch id="maintenance-alert" />
-              </div>
-            </CardContent>
-          </Card>
+      {/* User Management */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Users className="h-5 w-5" />
+            <CardTitle>Manajemen Pengguna</CardTitle>
+          </div>
+          <CardDescription>Kelola akses dan peran pengguna</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <Label htmlFor="multi-admin">Multi Admin</Label>
+              <p className="text-sm text-muted-foreground">
+                Izinkan beberapa admin mengelola sistem
+              </p>
+            </div>
+            <Switch id="multi-admin" defaultChecked />
+          </div>
+          <div className="flex items-center justify-between">
+            <div>
+              <Label htmlFor="staff-access">Akses Staff</Label>
+              <p className="text-sm text-muted-foreground">
+                Berikan akses terbatas untuk staff
+              </p>
+            </div>
+            <Switch id="staff-access" defaultChecked />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="session-timeout">Timeout Sesi (menit)</Label>
+            <Input id="session-timeout" type="number" defaultValue="60" />
+          </div>
+        </CardContent>
+      </Card>
 
-          {/* User Management */}
-          <Card>
-            <CardHeader>
-              <div className="flex items-center gap-2">
-                <Users className="h-5 w-5" />
-                <CardTitle>Manajemen Pengguna</CardTitle>
-              </div>
-              <CardDescription>Kelola akses dan peran pengguna</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label htmlFor="multi-admin">Multi Admin</Label>
-                  <p className="text-sm text-muted-foreground">
-                    Izinkan beberapa admin mengelola sistem
-                  </p>
-                </div>
-                <Switch id="multi-admin" defaultChecked />
-              </div>
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label htmlFor="staff-access">Akses Staff</Label>
-                  <p className="text-sm text-muted-foreground">
-                    Berikan akses terbatas untuk staff
-                  </p>
-                </div>
-                <Switch id="staff-access" defaultChecked />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="session-timeout">Timeout Sesi (menit)</Label>
-                <Input id="session-timeout" type="number" defaultValue="60" />
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Security Settings */}
-          <Card>
-            <CardHeader>
-              <div className="flex items-center gap-2">
-                <Shield className="h-5 w-5" />
-                <CardTitle>Keamanan</CardTitle>
-              </div>
-              <CardDescription>Pengaturan keamanan sistem</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="current-password">Password Saat Ini</Label>
-                <Input id="current-password" type="password" />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="new-password">Password Baru</Label>
-                <Input id="new-password" type="password" />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="confirm-password">
-                  Konfirmasi Password Baru
-                </Label>
-                <Input id="confirm-password" type="password" />
-              </div>
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label htmlFor="two-factor">Autentikasi Dua Faktor</Label>
-                  <p className="text-sm text-muted-foreground">
-                    Tambahan keamanan dengan SMS/Email
-                  </p>
-                </div>
-                <Switch id="two-factor" />
-              </div>
-              <Button>Ubah Password</Button>
-            </CardContent>
-          </Card>
-        </div>
-      </DashboardLayout>
-    </ProtectedRoute>
+      {/* Security Settings */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Shield className="h-5 w-5" />
+            <CardTitle>Keamanan</CardTitle>
+          </div>
+          <CardDescription>Pengaturan keamanan sistem</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="current-password">Password Saat Ini</Label>
+            <Input id="current-password" type="password" />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="new-password">Password Baru</Label>
+            <Input id="new-password" type="password" />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="confirm-password">Konfirmasi Password Baru</Label>
+            <Input id="confirm-password" type="password" />
+          </div>
+          <div className="flex items-center justify-between">
+            <div>
+              <Label htmlFor="two-factor">Autentikasi Dua Faktor</Label>
+              <p className="text-sm text-muted-foreground">
+                Tambahan keamanan dengan SMS/Email
+              </p>
+            </div>
+            <Switch id="two-factor" />
+          </div>
+          <Button>Ubah Password</Button>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/src/app/bumdes/unit-usaha/page.tsx
+++ b/src/app/bumdes/unit-usaha/page.tsx
@@ -1,7 +1,5 @@
 /** @format */
 
-import { ProtectedRoute } from "@/components/shared/protected-route";
-import { DashboardLayout } from "@/components/shared/dashboard-layout";
 import {
   Card,
   CardContent,
@@ -12,49 +10,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import {
-  BarChart3,
-  Building,
-  Calendar,
-  FileText,
-  Settings,
-  Plus,
-  Search,
-  Edit,
-  Eye,
-  TrendingUp,
-  Users,
-  MapPin,
-} from "lucide-react";
-
-const bumdesNavigation = [
-  {
-    name: "Dashboard",
-    href: "/dashboard",
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    name: "Unit Usaha",
-    href: "/unit-usaha",
-    icon: <Building className="h-4 w-4" />,
-  },
-  {
-    name: "Aset Sewa",
-    href: "/aset-sewa",
-    icon: <MapPin className="h-4 w-4" />,
-  },
-  {
-    name: "Jadwal Sewa",
-    href: "/jadwal-sewa",
-    icon: <Calendar className="h-4 w-4" />,
-  },
-  { name: "Laporan", href: "/laporan", icon: <FileText className="h-4 w-4" /> },
-  {
-    name: "Pengaturan",
-    href: "/pengaturan",
-    icon: <Settings className="h-4 w-4" />,
-  },
-];
+import { Plus, Search, Edit, Eye, TrendingUp, Users } from "lucide-react";
 
 const businessUnits = [
   {
@@ -105,171 +61,160 @@ const businessUnits = [
 
 export default function UnitUsahaPage() {
   return (
-    <ProtectedRoute requiredRole="bumdes">
-      <DashboardLayout
-        title="Manajemen Unit Usaha"
-        navigation={bumdesNavigation}
-      >
-        <div className="space-y-6">
-          {/* Header */}
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-2xl font-bold">Unit Usaha</h2>
-              <p className="text-muted-foreground">Kelola unit usaha BUMDes</p>
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold">Unit Usaha</h2>
+          <p className="text-muted-foreground">Kelola unit usaha BUMDes</p>
+        </div>
+        <Button>
+          <Plus className="h-4 w-4 mr-2" />
+          Tambah Unit Usaha
+        </Button>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">
+              Total Unit Usaha
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">12</div>
+            <p className="text-xs text-muted-foreground">+2 unit baru</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">Unit Aktif</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">9</div>
+            <p className="text-xs text-muted-foreground">75% dari total</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">
+              Total Karyawan
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">45</div>
+            <p className="text-xs text-muted-foreground">Warga terlibat</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">
+              Pendapatan Bulan Ini
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">Rp 43M</div>
+            <p className="text-xs text-muted-foreground">
+              +18.2% dari bulan lalu
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Search */}
+      <Card>
+        <CardContent className="pt-6">
+          <div className="flex items-center gap-4">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input placeholder="Cari unit usaha..." className="pl-10" />
             </div>
-            <Button>
-              <Plus className="h-4 w-4 mr-2" />
-              Tambah Unit Usaha
-            </Button>
+            <Button variant="outline">Filter Kategori</Button>
           </div>
+        </CardContent>
+      </Card>
 
-          {/* Stats */}
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Total Unit Usaha
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">12</div>
-                <p className="text-xs text-muted-foreground">+2 unit baru</p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Unit Aktif
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">9</div>
-                <p className="text-xs text-muted-foreground">75% dari total</p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Total Karyawan
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">45</div>
-                <p className="text-xs text-muted-foreground">Warga terlibat</p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Pendapatan Bulan Ini
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">Rp 43M</div>
-                <p className="text-xs text-muted-foreground">
-                  +18.2% dari bulan lalu
-                </p>
-              </CardContent>
-            </Card>
-          </div>
-
-          {/* Search */}
-          <Card>
-            <CardContent className="pt-6">
-              <div className="flex items-center gap-4">
-                <div className="relative flex-1">
-                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                  <Input placeholder="Cari unit usaha..." className="pl-10" />
+      {/* Business Units Grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {businessUnits.map((unit) => (
+          <Card key={unit.id}>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <div>
+                  <CardTitle className="text-lg">{unit.name}</CardTitle>
+                  <CardDescription>
+                    {unit.type} • {unit.location}
+                  </CardDescription>
                 </div>
-                <Button variant="outline">Filter Kategori</Button>
+                <Badge
+                  variant={
+                    unit.status === "aktif"
+                      ? "default"
+                      : unit.status === "berkembang"
+                        ? "secondary"
+                        : "outline"
+                  }
+                >
+                  {unit.status}
+                </Badge>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <p className="text-sm text-muted-foreground">Pengelola</p>
+                  <p className="font-medium">{unit.manager}</p>
+                </div>
+                <div>
+                  <p className="text-sm text-muted-foreground">Karyawan</p>
+                  <div className="flex items-center gap-1">
+                    <Users className="h-4 w-4" />
+                    <span className="font-medium">{unit.employees} orang</span>
+                  </div>
+                </div>
+              </div>
+
+              <div>
+                <p className="text-sm text-muted-foreground">
+                  Pendapatan Bulan Ini
+                </p>
+                <div className="flex items-center gap-2">
+                  <p className="text-xl font-bold">{unit.revenue}</p>
+                  <div className="flex items-center gap-1 text-xs text-green-600">
+                    <TrendingUp className="h-3 w-3" />
+                    <span>+15%</span>
+                  </div>
+                </div>
+              </div>
+
+              <div>
+                <p className="text-sm text-muted-foreground">Didirikan</p>
+                <p className="font-medium">{unit.established}</p>
+              </div>
+
+              <div className="flex gap-2 pt-4">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="flex-1 bg-transparent"
+                >
+                  <Eye className="h-4 w-4 mr-2" />
+                  Detail
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="flex-1 bg-transparent"
+                >
+                  <Edit className="h-4 w-4 mr-2" />
+                  Edit
+                </Button>
               </div>
             </CardContent>
           </Card>
-
-          {/* Business Units Grid */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            {businessUnits.map((unit) => (
-              <Card key={unit.id}>
-                <CardHeader>
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <CardTitle className="text-lg">{unit.name}</CardTitle>
-                      <CardDescription>
-                        {unit.type} • {unit.location}
-                      </CardDescription>
-                    </div>
-                    <Badge
-                      variant={
-                        unit.status === "aktif"
-                          ? "default"
-                          : unit.status === "berkembang"
-                          ? "secondary"
-                          : "outline"
-                      }
-                    >
-                      {unit.status}
-                    </Badge>
-                  </div>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div className="grid grid-cols-2 gap-4">
-                    <div>
-                      <p className="text-sm text-muted-foreground">Pengelola</p>
-                      <p className="font-medium">{unit.manager}</p>
-                    </div>
-                    <div>
-                      <p className="text-sm text-muted-foreground">Karyawan</p>
-                      <div className="flex items-center gap-1">
-                        <Users className="h-4 w-4" />
-                        <span className="font-medium">
-                          {unit.employees} orang
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div>
-                    <p className="text-sm text-muted-foreground">
-                      Pendapatan Bulan Ini
-                    </p>
-                    <div className="flex items-center gap-2">
-                      <p className="text-xl font-bold">{unit.revenue}</p>
-                      <div className="flex items-center gap-1 text-xs text-green-600">
-                        <TrendingUp className="h-3 w-3" />
-                        <span>+15%</span>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div>
-                    <p className="text-sm text-muted-foreground">Didirikan</p>
-                    <p className="font-medium">{unit.established}</p>
-                  </div>
-
-                  <div className="flex gap-2 pt-4">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="flex-1 bg-transparent"
-                    >
-                      <Eye className="h-4 w-4 mr-2" />
-                      Detail
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="flex-1 bg-transparent"
-                    >
-                      <Edit className="h-4 w-4 mr-2" />
-                      Edit
-                    </Button>
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </div>
-      </DashboardLayout>
-    </ProtectedRoute>
+        ))}
+      </div>
+    </div>
   );
 }

--- a/src/app/koperasi/dashboard/page.tsx
+++ b/src/app/koperasi/dashboard/page.tsx
@@ -1,7 +1,5 @@
 /** @format */
 
-import { ProtectedRoute } from "@/components/shared/protected-route";
-import { DashboardLayout } from "@/components/shared/dashboard-layout";
 import {
   Card,
   CardContent,
@@ -11,63 +9,15 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import {
-  BarChart3,
   Users,
   PiggyBank,
   CreditCard,
   TrendingUp,
-  Building,
-  Receipt,
   FileText,
-  Settings,
-  MessageCircle,
   DollarSign,
   UserPlus,
   Calendar,
 } from "lucide-react";
-
-const koperasiNavigation = [
-  {
-    name: "Dashboard",
-    href: "/dashboard",
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    name: "Keanggotaan",
-    href: "/keanggotaan",
-    icon: <Users className="h-4 w-4" />,
-  },
-  {
-    name: "Simpanan",
-    href: "/simpanan",
-    icon: <PiggyBank className="h-4 w-4" />,
-  },
-  {
-    name: "Pinjaman",
-    href: "/pinjaman",
-    icon: <CreditCard className="h-4 w-4" />,
-  },
-  { name: "SHU", href: "/shu", icon: <TrendingUp className="h-4 w-4" /> },
-  { name: "RAT", href: "/rat", icon: <Calendar className="h-4 w-4" /> },
-  { name: "Aset", href: "/aset", icon: <Building className="h-4 w-4" /> },
-  {
-    name: "Transaksi",
-    href: "/transaksi",
-    icon: <Receipt className="h-4 w-4" />,
-  },
-  { name: "Laporan", href: "/laporan", icon: <FileText className="h-4 w-4" /> },
-  {
-    name: "Pengaturan",
-    href: "/pengaturan",
-    icon: <Settings className="h-4 w-4" />,
-  },
-  { name: "Tagihan", href: "/tagihan", icon: <Receipt className="h-4 w-4" /> },
-  {
-    name: "Chat Support",
-    href: "/chat-support",
-    icon: <MessageCircle className="h-4 w-4" />,
-  },
-];
 
 const dashboardStats = [
   {
@@ -102,202 +52,190 @@ const dashboardStats = [
 
 export default function KoperasiDashboard() {
   return (
-    <ProtectedRoute requiredRole="koperasi">
-      <DashboardLayout
-        title="Dashboard Koperasi"
-        navigation={koperasiNavigation}
-      >
-        <div className="space-y-6">
-          {/* Stats Cards */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {dashboardStats.map((stat) => (
-              <Card key={stat.title}>
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                  <CardTitle className="text-sm font-medium">
-                    {stat.title}
-                  </CardTitle>
-                  {stat.icon}
-                </CardHeader>
-                <CardContent>
-                  <div className="text-2xl font-bold">{stat.value}</div>
-                  <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                    <TrendingUp
-                      className={`h-3 w-3 ${
-                        stat.trend === "up" ? "text-green-500" : "text-red-500"
-                      }`}
-                    />
-                    <span
-                      className={
-                        stat.trend === "up" ? "text-green-500" : "text-red-500"
-                      }
-                    >
-                      {stat.change}
-                    </span>
-                    <span>dari bulan lalu</span>
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-
-          {/* Recent Activity */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <Card>
-              <CardHeader>
-                <CardTitle>Aktivitas Terbaru</CardTitle>
-                <CardDescription>
-                  Transaksi dan aktivitas anggota terbaru
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-4">
-                  {[
-                    {
-                      member: "Budi Santoso",
-                      activity: "Setoran Simpanan Pokok",
-                      amount: "Rp 500,000",
-                      type: "simpanan",
-                    },
-                    {
-                      member: "Siti Aminah",
-                      activity: "Pengajuan Pinjaman",
-                      amount: "Rp 2,000,000",
-                      type: "pinjaman",
-                    },
-                    {
-                      member: "Ahmad Wijaya",
-                      activity: "Pelunasan Pinjaman",
-                      amount: "Rp 1,500,000",
-                      type: "pelunasan",
-                    },
-                  ].map((activity, index) => (
-                    <div
-                      key={index}
-                      className="flex items-center justify-between"
-                    >
-                      <div>
-                        <p className="font-medium">{activity.member}</p>
-                        <p className="text-sm text-muted-foreground">
-                          {activity.activity}
-                        </p>
-                      </div>
-                      <div className="text-right">
-                        <p className="font-medium">{activity.amount}</p>
-                        <Badge
-                          variant={
-                            activity.type === "simpanan"
-                              ? "default"
-                              : activity.type === "pinjaman"
-                              ? "secondary"
-                              : "outline"
-                          }
-                        >
-                          {activity.type}
-                        </Badge>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle>Aksi Cepat</CardTitle>
-                <CardDescription>Fitur yang sering digunakan</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="grid grid-cols-2 gap-4">
-                  <a
-                    href="/keanggotaan"
-                    className="p-4 border rounded-lg hover:bg-muted transition-colors"
-                  >
-                    <UserPlus className="h-6 w-6 mb-2" />
-                    <p className="font-medium">Tambah Anggota</p>
-                    <p className="text-sm text-muted-foreground">
-                      Daftarkan anggota baru
-                    </p>
-                  </a>
-                  <a
-                    href="/simpanan"
-                    className="p-4 border rounded-lg hover:bg-muted transition-colors"
-                  >
-                    <PiggyBank className="h-6 w-6 mb-2" />
-                    <p className="font-medium">Setoran Simpanan</p>
-                    <p className="text-sm text-muted-foreground">
-                      Catat setoran anggota
-                    </p>
-                  </a>
-                  <a
-                    href="/pinjaman"
-                    className="p-4 border rounded-lg hover:bg-muted transition-colors"
-                  >
-                    <CreditCard className="h-6 w-6 mb-2" />
-                    <p className="font-medium">Proses Pinjaman</p>
-                    <p className="text-sm text-muted-foreground">
-                      Kelola pengajuan pinjaman
-                    </p>
-                  </a>
-                  <a
-                    href="/laporan"
-                    className="p-4 border rounded-lg hover:bg-muted transition-colors"
-                  >
-                    <FileText className="h-6 w-6 mb-2" />
-                    <p className="font-medium">Laporan</p>
-                    <p className="text-sm text-muted-foreground">
-                      Lihat laporan keuangan
-                    </p>
-                  </a>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-
-          {/* Upcoming Events */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Agenda Mendatang</CardTitle>
-              <CardDescription>
-                Kegiatan dan rapat yang akan datang
-              </CardDescription>
+    <div className="space-y-6">
+      {/* Stats Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        {dashboardStats.map((stat) => (
+          <Card key={stat.title}>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">
+                {stat.title}
+              </CardTitle>
+              {stat.icon}
             </CardHeader>
             <CardContent>
-              <div className="space-y-3">
-                {[
-                  {
-                    event: "Rapat Anggota Tahunan (RAT)",
-                    date: "15 Februari 2024",
-                    time: "09:00 WIB",
-                  },
-                  {
-                    event: "Pembagian SHU",
-                    date: "20 Februari 2024",
-                    time: "10:00 WIB",
-                  },
-                  {
-                    event: "Sosialisasi Produk Simpanan Baru",
-                    date: "25 Februari 2024",
-                    time: "14:00 WIB",
-                  },
-                ].map((agenda, index) => (
-                  <div
-                    key={index}
-                    className="flex items-center justify-between p-3 border rounded-lg"
-                  >
-                    <div>
-                      <p className="font-medium">{agenda.event}</p>
-                      <p className="text-sm text-muted-foreground">
-                        {agenda.date} • {agenda.time}
-                      </p>
-                    </div>
-                    <Calendar className="h-5 w-5 text-muted-foreground" />
-                  </div>
-                ))}
+              <div className="text-2xl font-bold">{stat.value}</div>
+              <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                <TrendingUp
+                  className={`h-3 w-3 ${
+                    stat.trend === "up" ? "text-green-500" : "text-red-500"
+                  }`}
+                />
+                <span
+                  className={
+                    stat.trend === "up" ? "text-green-500" : "text-red-500"
+                  }
+                >
+                  {stat.change}
+                </span>
+                <span>dari bulan lalu</span>
               </div>
             </CardContent>
           </Card>
-        </div>
-      </DashboardLayout>
-    </ProtectedRoute>
+        ))}
+      </div>
+
+      {/* Recent Activity */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Aktivitas Terbaru</CardTitle>
+            <CardDescription>
+              Transaksi dan aktivitas anggota terbaru
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              {[
+                {
+                  member: "Budi Santoso",
+                  activity: "Setoran Simpanan Pokok",
+                  amount: "Rp 500,000",
+                  type: "simpanan",
+                },
+                {
+                  member: "Siti Aminah",
+                  activity: "Pengajuan Pinjaman",
+                  amount: "Rp 2,000,000",
+                  type: "pinjaman",
+                },
+                {
+                  member: "Ahmad Wijaya",
+                  activity: "Pelunasan Pinjaman",
+                  amount: "Rp 1,500,000",
+                  type: "pelunasan",
+                },
+              ].map((activity, index) => (
+                <div key={index} className="flex items-center justify-between">
+                  <div>
+                    <p className="font-medium">{activity.member}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {activity.activity}
+                    </p>
+                  </div>
+                  <div className="text-right">
+                    <p className="font-medium">{activity.amount}</p>
+                    <Badge
+                      variant={
+                        activity.type === "simpanan"
+                          ? "default"
+                          : activity.type === "pinjaman"
+                            ? "secondary"
+                            : "outline"
+                      }
+                    >
+                      {activity.type}
+                    </Badge>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Aksi Cepat</CardTitle>
+            <CardDescription>Fitur yang sering digunakan</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-2 gap-4">
+              <a
+                href="/keanggotaan"
+                className="p-4 border rounded-lg hover:bg-muted transition-colors"
+              >
+                <UserPlus className="h-6 w-6 mb-2" />
+                <p className="font-medium">Tambah Anggota</p>
+                <p className="text-sm text-muted-foreground">
+                  Daftarkan anggota baru
+                </p>
+              </a>
+              <a
+                href="/simpanan"
+                className="p-4 border rounded-lg hover:bg-muted transition-colors"
+              >
+                <PiggyBank className="h-6 w-6 mb-2" />
+                <p className="font-medium">Setoran Simpanan</p>
+                <p className="text-sm text-muted-foreground">
+                  Catat setoran anggota
+                </p>
+              </a>
+              <a
+                href="/pinjaman"
+                className="p-4 border rounded-lg hover:bg-muted transition-colors"
+              >
+                <CreditCard className="h-6 w-6 mb-2" />
+                <p className="font-medium">Proses Pinjaman</p>
+                <p className="text-sm text-muted-foreground">
+                  Kelola pengajuan pinjaman
+                </p>
+              </a>
+              <a
+                href="/laporan"
+                className="p-4 border rounded-lg hover:bg-muted transition-colors"
+              >
+                <FileText className="h-6 w-6 mb-2" />
+                <p className="font-medium">Laporan</p>
+                <p className="text-sm text-muted-foreground">
+                  Lihat laporan keuangan
+                </p>
+              </a>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Upcoming Events */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Agenda Mendatang</CardTitle>
+          <CardDescription>Kegiatan dan rapat yang akan datang</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {[
+              {
+                event: "Rapat Anggota Tahunan (RAT)",
+                date: "15 Februari 2024",
+                time: "09:00 WIB",
+              },
+              {
+                event: "Pembagian SHU",
+                date: "20 Februari 2024",
+                time: "10:00 WIB",
+              },
+              {
+                event: "Sosialisasi Produk Simpanan Baru",
+                date: "25 Februari 2024",
+                time: "14:00 WIB",
+              },
+            ].map((agenda, index) => (
+              <div
+                key={index}
+                className="flex items-center justify-between p-3 border rounded-lg"
+              >
+                <div>
+                  <p className="font-medium">{agenda.event}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {agenda.date} • {agenda.time}
+                  </p>
+                </div>
+                <Calendar className="h-5 w-5 text-muted-foreground" />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/src/app/koperasi/keanggotaan/page.tsx
+++ b/src/app/koperasi/keanggotaan/page.tsx
@@ -1,7 +1,5 @@
 /** @format */
 
-import { ProtectedRoute } from "@/components/shared/protected-route";
-import { DashboardLayout } from "@/components/shared/dashboard-layout";
 import {
   Card,
   CardContent,
@@ -12,66 +10,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import {
-  BarChart3,
-  Users,
-  PiggyBank,
-  CreditCard,
-  TrendingUp,
-  Building,
-  Receipt,
-  FileText,
-  Settings,
-  MessageCircle,
-  Plus,
-  Search,
-  Edit,
-  Eye,
-  Calendar,
-} from "lucide-react";
-
-const koperasiNavigation = [
-  {
-    name: "Dashboard",
-    href: "/dashboard",
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    name: "Keanggotaan",
-    href: "/keanggotaan",
-    icon: <Users className="h-4 w-4" />,
-  },
-  {
-    name: "Simpanan",
-    href: "/simpanan",
-    icon: <PiggyBank className="h-4 w-4" />,
-  },
-  {
-    name: "Pinjaman",
-    href: "/pinjaman",
-    icon: <CreditCard className="h-4 w-4" />,
-  },
-  { name: "SHU", href: "/shu", icon: <TrendingUp className="h-4 w-4" /> },
-  { name: "RAT", href: "/rat", icon: <Calendar className="h-4 w-4" /> },
-  { name: "Aset", href: "/aset", icon: <Building className="h-4 w-4" /> },
-  {
-    name: "Transaksi",
-    href: "/transaksi",
-    icon: <Receipt className="h-4 w-4" />,
-  },
-  { name: "Laporan", href: "/laporan", icon: <FileText className="h-4 w-4" /> },
-  {
-    name: "Pengaturan",
-    href: "/pengaturan",
-    icon: <Settings className="h-4 w-4" />,
-  },
-  { name: "Tagihan", href: "/tagihan", icon: <Receipt className="h-4 w-4" /> },
-  {
-    name: "Chat Support",
-    href: "/chat-support",
-    icon: <MessageCircle className="h-4 w-4" />,
-  },
-];
+import { Users, Plus, Search, Edit, Eye } from "lucide-react";
 
 const members = [
   {
@@ -108,139 +47,124 @@ const members = [
 
 export default function KeanggotaanPage() {
   return (
-    <ProtectedRoute requiredRole="koperasi">
-      <DashboardLayout
-        title="Manajemen Keanggotaan"
-        navigation={koperasiNavigation}
-      >
-        <div className="space-y-6">
-          {/* Header */}
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-2xl font-bold">Keanggotaan</h2>
-              <p className="text-muted-foreground">
-                Kelola data anggota koperasi
-              </p>
-            </div>
-            <Button>
-              <Plus className="h-4 w-4 mr-2" />
-              Tambah Anggota
-            </Button>
-          </div>
-
-          {/* Stats */}
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Total Anggota
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">1,247</div>
-                <p className="text-xs text-muted-foreground">
-                  +23 anggota baru bulan ini
-                </p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Anggota Aktif
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">1,189</div>
-                <p className="text-xs text-muted-foreground">
-                  95.3% dari total anggota
-                </p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Anggota Baru
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">23</div>
-                <p className="text-xs text-muted-foreground">Bulan ini</p>
-              </CardContent>
-            </Card>
-          </div>
-
-          {/* Search */}
-          <Card>
-            <CardContent className="pt-6">
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                <Input placeholder="Cari anggota..." className="pl-10" />
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Members Table */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Daftar Anggota</CardTitle>
-              <CardDescription>Data lengkap anggota koperasi</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                {members.map((member) => (
-                  <div
-                    key={member.id}
-                    className="flex items-center justify-between p-4 border rounded-lg"
-                  >
-                    <div className="flex items-center gap-4">
-                      <div className="w-12 h-12 bg-muted rounded-full flex items-center justify-center">
-                        <Users className="h-6 w-6" />
-                      </div>
-                      <div>
-                        <h3 className="font-medium">{member.name}</h3>
-                        <p className="text-sm text-muted-foreground">
-                          ID: {member.id} • {member.email}
-                        </p>
-                        <p className="text-sm text-muted-foreground">
-                          Bergabung: {member.joinDate}
-                        </p>
-                      </div>
-                    </div>
-
-                    <div className="flex items-center gap-6">
-                      <div className="text-right">
-                        <p className="text-sm font-medium">
-                          Simpanan Pokok: {member.simpananPokok}
-                        </p>
-                        <p className="text-sm text-muted-foreground">
-                          Simpanan Wajib: {member.simpananWajib}
-                        </p>
-                      </div>
-
-                      <Badge
-                        variant={
-                          member.status === "aktif" ? "default" : "secondary"
-                        }
-                      >
-                        {member.status}
-                      </Badge>
-
-                      <div className="flex items-center gap-2">
-                        <Button variant="ghost" size="icon">
-                          <Eye className="h-4 w-4" />
-                        </Button>
-                        <Button variant="ghost" size="icon">
-                          <Edit className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold">Keanggotaan</h2>
+          <p className="text-muted-foreground">Kelola data anggota koperasi</p>
         </div>
-      </DashboardLayout>
-    </ProtectedRoute>
+        <Button>
+          <Plus className="h-4 w-4 mr-2" />
+          Tambah Anggota
+        </Button>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">Total Anggota</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">1,247</div>
+            <p className="text-xs text-muted-foreground">
+              +23 anggota baru bulan ini
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">Anggota Aktif</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">1,189</div>
+            <p className="text-xs text-muted-foreground">
+              95.3% dari total anggota
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">Anggota Baru</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">23</div>
+            <p className="text-xs text-muted-foreground">Bulan ini</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Search */}
+      <Card>
+        <CardContent className="pt-6">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input placeholder="Cari anggota..." className="pl-10" />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Members Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Daftar Anggota</CardTitle>
+          <CardDescription>Data lengkap anggota koperasi</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {members.map((member) => (
+              <div
+                key={member.id}
+                className="flex items-center justify-between p-4 border rounded-lg"
+              >
+                <div className="flex items-center gap-4">
+                  <div className="w-12 h-12 bg-muted rounded-full flex items-center justify-center">
+                    <Users className="h-6 w-6" />
+                  </div>
+                  <div>
+                    <h3 className="font-medium">{member.name}</h3>
+                    <p className="text-sm text-muted-foreground">
+                      ID: {member.id} • {member.email}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      Bergabung: {member.joinDate}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-6">
+                  <div className="text-right">
+                    <p className="text-sm font-medium">
+                      Simpanan Pokok: {member.simpananPokok}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      Simpanan Wajib: {member.simpananWajib}
+                    </p>
+                  </div>
+
+                  <Badge
+                    variant={
+                      member.status === "aktif" ? "default" : "secondary"
+                    }
+                  >
+                    {member.status}
+                  </Badge>
+
+                  <div className="flex items-center gap-2">
+                    <Button variant="ghost" size="icon">
+                      <Eye className="h-4 w-4" />
+                    </Button>
+                    <Button variant="ghost" size="icon">
+                      <Edit className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/src/app/koperasi/pinjaman/page.tsx
+++ b/src/app/koperasi/pinjaman/page.tsx
@@ -1,7 +1,5 @@
 /** @format */
 
-import { ProtectedRoute } from "@/components/shared/protected-route";
-import { DashboardLayout } from "@/components/shared/dashboard-layout";
 import {
   Card,
   CardContent,
@@ -13,67 +11,14 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import {
-  BarChart3,
-  Users,
-  PiggyBank,
   CreditCard,
-  TrendingUp,
-  Building,
-  Receipt,
-  FileText,
-  Settings,
-  MessageCircle,
   Plus,
   Search,
   Eye,
   CheckCircle,
   XCircle,
   Clock,
-  Calendar,
 } from "lucide-react";
-
-const koperasiNavigation = [
-  {
-    name: "Dashboard",
-    href: "/dashboard",
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    name: "Keanggotaan",
-    href: "/keanggotaan",
-    icon: <Users className="h-4 w-4" />,
-  },
-  {
-    name: "Simpanan",
-    href: "/simpanan",
-    icon: <PiggyBank className="h-4 w-4" />,
-  },
-  {
-    name: "Pinjaman",
-    href: "/pinjaman",
-    icon: <CreditCard className="h-4 w-4" />,
-  },
-  { name: "SHU", href: "/shu", icon: <TrendingUp className="h-4 w-4" /> },
-  { name: "RAT", href: "/rat", icon: <Calendar className="h-4 w-4" /> },
-  { name: "Aset", href: "/aset", icon: <Building className="h-4 w-4" /> },
-  {
-    name: "Transaksi",
-    href: "/transaksi",
-    icon: <Receipt className="h-4 w-4" />,
-  },
-  { name: "Laporan", href: "/laporan", icon: <FileText className="h-4 w-4" /> },
-  {
-    name: "Pengaturan",
-    href: "/pengaturan",
-    icon: <Settings className="h-4 w-4" />,
-  },
-  { name: "Tagihan", href: "/tagihan", icon: <Receipt className="h-4 w-4" /> },
-  {
-    name: "Chat Support",
-    href: "/chat-support",
-    icon: <MessageCircle className="h-4 w-4" />,
-  },
-];
 
 const pinjamanData = [
   {
@@ -116,173 +61,160 @@ const pinjamanData = [
 
 export default function PinjamanPage() {
   return (
-    <ProtectedRoute requiredRole="koperasi">
-      <DashboardLayout
-        title="Manajemen Pinjaman"
-        navigation={koperasiNavigation}
-      >
-        <div className="space-y-6">
-          {/* Header */}
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-2xl font-bold">Pinjaman</h2>
-              <p className="text-muted-foreground">
-                Kelola pinjaman anggota koperasi
-              </p>
-            </div>
-            <Button>
-              <Plus className="h-4 w-4 mr-2" />
-              Pengajuan Baru
-            </Button>
-          </div>
-
-          {/* Stats */}
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Total Pinjaman
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">Rp 1.8M</div>
-                <p className="text-xs text-muted-foreground">Pinjaman aktif</p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Menunggu Persetujuan
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">5</div>
-                <p className="text-xs text-muted-foreground">Pengajuan baru</p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Pinjaman Aktif
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">23</div>
-                <p className="text-xs text-muted-foreground">Sedang berjalan</p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">Tunggakan</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">2</div>
-                <p className="text-xs text-muted-foreground">
-                  Perlu tindak lanjut
-                </p>
-              </CardContent>
-            </Card>
-          </div>
-
-          {/* Search */}
-          <Card>
-            <CardContent className="pt-6">
-              <div className="flex items-center gap-4">
-                <div className="relative flex-1">
-                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                  <Input placeholder="Cari pinjaman..." className="pl-10" />
-                </div>
-                <Button variant="outline">Filter</Button>
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Loans Table */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Daftar Pinjaman</CardTitle>
-              <CardDescription>
-                Status dan detail pinjaman anggota
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                {pinjamanData.map((pinjaman) => (
-                  <div
-                    key={pinjaman.id}
-                    className="flex items-center justify-between p-4 border rounded-lg"
-                  >
-                    <div className="flex items-center gap-4">
-                      <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
-                        {pinjaman.status === "aktif" && (
-                          <CreditCard className="h-6 w-6 text-blue-600" />
-                        )}
-                        {pinjaman.status === "menunggu" && (
-                          <Clock className="h-6 w-6 text-yellow-600" />
-                        )}
-                        {pinjaman.status === "lunas" && (
-                          <CheckCircle className="h-6 w-6 text-green-600" />
-                        )}
-                      </div>
-                      <div>
-                        <h3 className="font-medium">{pinjaman.memberName}</h3>
-                        <p className="text-sm text-muted-foreground">
-                          {pinjaman.id} • {pinjaman.purpose}
-                        </p>
-                        <p className="text-sm text-muted-foreground">
-                          {pinjaman.amount} • {pinjaman.term}
-                        </p>
-                      </div>
-                    </div>
-
-                    <div className="flex items-center gap-6">
-                      <div className="text-right">
-                        <p className="font-medium">
-                          Sisa: {pinjaman.remaining}
-                        </p>
-                        <p className="text-sm text-muted-foreground">
-                          Angsuran: {pinjaman.installment}
-                        </p>
-                        <p className="text-sm text-muted-foreground">
-                          Jatuh tempo: {pinjaman.dueDate}
-                        </p>
-                      </div>
-
-                      <Badge
-                        variant={
-                          pinjaman.status === "aktif"
-                            ? "default"
-                            : pinjaman.status === "menunggu"
-                            ? "secondary"
-                            : "outline"
-                        }
-                      >
-                        {pinjaman.status}
-                      </Badge>
-
-                      <div className="flex items-center gap-2">
-                        <Button variant="ghost" size="icon">
-                          <Eye className="h-4 w-4" />
-                        </Button>
-                        {pinjaman.status === "menunggu" && (
-                          <>
-                            <Button variant="ghost" size="icon">
-                              <CheckCircle className="h-4 w-4 text-green-600" />
-                            </Button>
-                            <Button variant="ghost" size="icon">
-                              <XCircle className="h-4 w-4 text-red-600" />
-                            </Button>
-                          </>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold">Pinjaman</h2>
+          <p className="text-muted-foreground">
+            Kelola pinjaman anggota koperasi
+          </p>
         </div>
-      </DashboardLayout>
-    </ProtectedRoute>
+        <Button>
+          <Plus className="h-4 w-4 mr-2" />
+          Pengajuan Baru
+        </Button>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">
+              Total Pinjaman
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">Rp 1.8M</div>
+            <p className="text-xs text-muted-foreground">Pinjaman aktif</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">
+              Menunggu Persetujuan
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">5</div>
+            <p className="text-xs text-muted-foreground">Pengajuan baru</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">
+              Pinjaman Aktif
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">23</div>
+            <p className="text-xs text-muted-foreground">Sedang berjalan</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">Tunggakan</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">2</div>
+            <p className="text-xs text-muted-foreground">Perlu tindak lanjut</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Search */}
+      <Card>
+        <CardContent className="pt-6">
+          <div className="flex items-center gap-4">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input placeholder="Cari pinjaman..." className="pl-10" />
+            </div>
+            <Button variant="outline">Filter</Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Loans Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Daftar Pinjaman</CardTitle>
+          <CardDescription>Status dan detail pinjaman anggota</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {pinjamanData.map((pinjaman) => (
+              <div
+                key={pinjaman.id}
+                className="flex items-center justify-between p-4 border rounded-lg"
+              >
+                <div className="flex items-center gap-4">
+                  <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
+                    {pinjaman.status === "aktif" && (
+                      <CreditCard className="h-6 w-6 text-blue-600" />
+                    )}
+                    {pinjaman.status === "menunggu" && (
+                      <Clock className="h-6 w-6 text-yellow-600" />
+                    )}
+                    {pinjaman.status === "lunas" && (
+                      <CheckCircle className="h-6 w-6 text-green-600" />
+                    )}
+                  </div>
+                  <div>
+                    <h3 className="font-medium">{pinjaman.memberName}</h3>
+                    <p className="text-sm text-muted-foreground">
+                      {pinjaman.id} • {pinjaman.purpose}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      {pinjaman.amount} • {pinjaman.term}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-6">
+                  <div className="text-right">
+                    <p className="font-medium">Sisa: {pinjaman.remaining}</p>
+                    <p className="text-sm text-muted-foreground">
+                      Angsuran: {pinjaman.installment}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      Jatuh tempo: {pinjaman.dueDate}
+                    </p>
+                  </div>
+
+                  <Badge
+                    variant={
+                      pinjaman.status === "aktif"
+                        ? "default"
+                        : pinjaman.status === "menunggu"
+                          ? "secondary"
+                          : "outline"
+                    }
+                  >
+                    {pinjaman.status}
+                  </Badge>
+
+                  <div className="flex items-center gap-2">
+                    <Button variant="ghost" size="icon">
+                      <Eye className="h-4 w-4" />
+                    </Button>
+                    {pinjaman.status === "menunggu" && (
+                      <>
+                        <Button variant="ghost" size="icon">
+                          <CheckCircle className="h-4 w-4 text-green-600" />
+                        </Button>
+                        <Button variant="ghost" size="icon">
+                          <XCircle className="h-4 w-4 text-red-600" />
+                        </Button>
+                      </>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/src/app/koperasi/rat/page.tsx
+++ b/src/app/koperasi/rat/page.tsx
@@ -1,7 +1,5 @@
 /** @format */
 
-import { ProtectedRoute } from "@/components/shared/protected-route";
-import { DashboardLayout } from "@/components/shared/dashboard-layout";
 import {
   Card,
   CardContent,
@@ -11,66 +9,7 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import {
-  BarChart3,
-  Users,
-  PiggyBank,
-  CreditCard,
-  TrendingUp,
-  Building,
-  Receipt,
-  FileText,
-  Settings,
-  MessageCircle,
-  Calendar,
-  Plus,
-  MapPin,
-  Clock,
-  UserCheck,
-} from "lucide-react";
-
-const koperasiNavigation = [
-  {
-    name: "Dashboard",
-    href: "/dashboard",
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    name: "Keanggotaan",
-    href: "/keanggotaan",
-    icon: <Users className="h-4 w-4" />,
-  },
-  {
-    name: "Simpanan",
-    href: "/simpanan",
-    icon: <PiggyBank className="h-4 w-4" />,
-  },
-  {
-    name: "Pinjaman",
-    href: "/pinjaman",
-    icon: <CreditCard className="h-4 w-4" />,
-  },
-  { name: "SHU", href: "/shu", icon: <TrendingUp className="h-4 w-4" /> },
-  { name: "RAT", href: "/rat", icon: <Calendar className="h-4 w-4" /> },
-  { name: "Aset", href: "/aset", icon: <Building className="h-4 w-4" /> },
-  {
-    name: "Transaksi",
-    href: "/transaksi",
-    icon: <Receipt className="h-4 w-4" />,
-  },
-  { name: "Laporan", href: "/laporan", icon: <FileText className="h-4 w-4" /> },
-  {
-    name: "Pengaturan",
-    href: "/pengaturan",
-    icon: <Settings className="h-4 w-4" />,
-  },
-  { name: "Tagihan", href: "/tagihan", icon: <Receipt className="h-4 w-4" /> },
-  {
-    name: "Chat Support",
-    href: "/chat-support",
-    icon: <MessageCircle className="h-4 w-4" />,
-  },
-];
+import { Calendar, Plus, MapPin, Clock, UserCheck } from "lucide-react";
 
 const ratHistory = [
   {
@@ -104,211 +43,192 @@ const ratHistory = [
 
 export default function RATPage() {
   return (
-    <ProtectedRoute requiredRole="koperasi">
-      <DashboardLayout
-        title="Rapat Anggota Tahunan (RAT)"
-        navigation={koperasiNavigation}
-      >
-        <div className="space-y-6">
-          {/* Header */}
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold">Rapat Anggota Tahunan (RAT)</h2>
+          <p className="text-muted-foreground">
+            Kelola dan pantau pelaksanaan RAT
+          </p>
+        </div>
+        <Button>
+          <Plus className="h-4 w-4 mr-2" />
+          Jadwalkan RAT
+        </Button>
+      </div>
+
+      {/* Upcoming RAT */}
+      <Card className="border-primary/50">
+        <CardHeader>
           <div className="flex items-center justify-between">
             <div>
-              <h2 className="text-2xl font-bold">
-                Rapat Anggota Tahunan (RAT)
-              </h2>
-              <p className="text-muted-foreground">
-                Kelola dan pantau pelaksanaan RAT
-              </p>
+              <CardTitle className="text-lg">RAT Mendatang</CardTitle>
+              <CardDescription>Rapat Anggota Tahunan 2024</CardDescription>
             </div>
-            <Button>
-              <Plus className="h-4 w-4 mr-2" />
-              Jadwalkan RAT
-            </Button>
+            <Badge variant="default">Terjadwal</Badge>
           </div>
-
-          {/* Upcoming RAT */}
-          <Card className="border-primary/50">
-            <CardHeader>
-              <div className="flex items-center justify-between">
-                <div>
-                  <CardTitle className="text-lg">RAT Mendatang</CardTitle>
-                  <CardDescription>Rapat Anggota Tahunan 2024</CardDescription>
-                </div>
-                <Badge variant="default">Terjadwal</Badge>
-              </div>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <div className="flex items-center gap-3">
-                  <Calendar className="h-5 w-5 text-muted-foreground" />
-                  <div>
-                    <p className="font-medium">15 Februari 2024</p>
-                    <p className="text-sm text-muted-foreground">
-                      09:00 - 12:00 WIB
-                    </p>
-                  </div>
-                </div>
-                <div className="flex items-center gap-3">
-                  <MapPin className="h-5 w-5 text-muted-foreground" />
-                  <div>
-                    <p className="font-medium">Aula Koperasi</p>
-                    <p className="text-sm text-muted-foreground">
-                      Jl. Koperasi No. 123
-                    </p>
-                  </div>
-                </div>
-                <div className="flex items-center gap-3">
-                  <UserCheck className="h-5 w-5 text-muted-foreground" />
-                  <div>
-                    <p className="font-medium">1,189 / 1,247 Anggota</p>
-                    <p className="text-sm text-muted-foreground">
-                      95.3% konfirmasi kehadiran
-                    </p>
-                  </div>
-                </div>
-              </div>
-
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div className="flex items-center gap-3">
+              <Calendar className="h-5 w-5 text-muted-foreground" />
               <div>
-                <h4 className="font-medium mb-2">Agenda RAT 2024:</h4>
-                <ul className="space-y-1">
-                  {ratHistory[0].agenda.map((item, index) => (
-                    <li
-                      key={index}
-                      className="text-sm text-muted-foreground flex items-center gap-2"
-                    >
-                      <div className="w-1.5 h-1.5 bg-primary rounded-full"></div>
-                      {item}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-
-              <div className="flex gap-2 pt-4">
-                <Button>Kelola Agenda</Button>
-                <Button variant="outline">Undang Anggota</Button>
-                <Button variant="outline">Cetak Undangan</Button>
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* RAT Statistics */}
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Total Anggota
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">1,247</div>
-                <p className="text-xs text-muted-foreground">Anggota aktif</p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Konfirmasi Kehadiran
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">1,189</div>
-                <p className="text-xs text-muted-foreground">
-                  95.3% dari total anggota
+                <p className="font-medium">15 Februari 2024</p>
+                <p className="text-sm text-muted-foreground">
+                  09:00 - 12:00 WIB
                 </p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">Kuorum</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold text-green-600">
-                  Tercapai
-                </div>
-                <p className="text-xs text-muted-foreground">Minimal 50% + 1</p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Hari Tersisa
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">23</div>
-                <p className="text-xs text-muted-foreground">Hari menuju RAT</p>
-              </CardContent>
-            </Card>
+              </div>
+            </div>
+            <div className="flex items-center gap-3">
+              <MapPin className="h-5 w-5 text-muted-foreground" />
+              <div>
+                <p className="font-medium">Aula Koperasi</p>
+                <p className="text-sm text-muted-foreground">
+                  Jl. Koperasi No. 123
+                </p>
+              </div>
+            </div>
+            <div className="flex items-center gap-3">
+              <UserCheck className="h-5 w-5 text-muted-foreground" />
+              <div>
+                <p className="font-medium">1,189 / 1,247 Anggota</p>
+                <p className="text-sm text-muted-foreground">
+                  95.3% konfirmasi kehadiran
+                </p>
+              </div>
+            </div>
           </div>
 
-          {/* RAT History */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Riwayat RAT</CardTitle>
-              <CardDescription>Data pelaksanaan RAT sebelumnya</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                {ratHistory.map((rat) => (
-                  <div
-                    key={rat.id}
-                    className="flex items-center justify-between p-4 border rounded-lg"
-                  >
-                    <div className="flex items-center gap-4">
-                      <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
-                        <Calendar className="h-6 w-6" />
-                      </div>
-                      <div>
-                        <h3 className="font-medium">{rat.title}</h3>
-                        <div className="flex items-center gap-4 text-sm text-muted-foreground">
-                          <span className="flex items-center gap-1">
-                            <Calendar className="h-3 w-3" />
-                            {rat.date}
-                          </span>
-                          <span className="flex items-center gap-1">
-                            <Clock className="h-3 w-3" />
-                            {rat.time}
-                          </span>
-                          <span className="flex items-center gap-1">
-                            <MapPin className="h-3 w-3" />
-                            {rat.location}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
+          <div>
+            <h4 className="font-medium mb-2">Agenda RAT 2024:</h4>
+            <ul className="space-y-1">
+              {ratHistory[0].agenda.map((item, index) => (
+                <li
+                  key={index}
+                  className="text-sm text-muted-foreground flex items-center gap-2"
+                >
+                  <div className="w-1.5 h-1.5 bg-primary rounded-full"></div>
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
 
-                    <div className="flex items-center gap-6">
-                      <div className="text-right">
-                        <p className="font-medium">
-                          {rat.attendees} / {rat.totalMembers} Anggota
-                        </p>
-                        <p className="text-sm text-muted-foreground">
-                          {((rat.attendees / rat.totalMembers) * 100).toFixed(
-                            1
-                          )}
-                          % kehadiran
-                        </p>
-                      </div>
+          <div className="flex gap-2 pt-4">
+            <Button>Kelola Agenda</Button>
+            <Button variant="outline">Undang Anggota</Button>
+            <Button variant="outline">Cetak Undangan</Button>
+          </div>
+        </CardContent>
+      </Card>
 
-                      <Badge
-                        variant={
-                          rat.status === "selesai" ? "default" : "secondary"
-                        }
-                      >
-                        {rat.status}
-                      </Badge>
+      {/* RAT Statistics */}
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">Total Anggota</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">1,247</div>
+            <p className="text-xs text-muted-foreground">Anggota aktif</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">
+              Konfirmasi Kehadiran
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">1,189</div>
+            <p className="text-xs text-muted-foreground">
+              95.3% dari total anggota
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">Kuorum</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-green-600">Tercapai</div>
+            <p className="text-xs text-muted-foreground">Minimal 50% + 1</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">Hari Tersisa</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">23</div>
+            <p className="text-xs text-muted-foreground">Hari menuju RAT</p>
+          </CardContent>
+        </Card>
+      </div>
 
-                      <Button variant="ghost" size="sm">
-                        Detail
-                      </Button>
+      {/* RAT History */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Riwayat RAT</CardTitle>
+          <CardDescription>Data pelaksanaan RAT sebelumnya</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {ratHistory.map((rat) => (
+              <div
+                key={rat.id}
+                className="flex items-center justify-between p-4 border rounded-lg"
+              >
+                <div className="flex items-center gap-4">
+                  <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
+                    <Calendar className="h-6 w-6" />
+                  </div>
+                  <div>
+                    <h3 className="font-medium">{rat.title}</h3>
+                    <div className="flex items-center gap-4 text-sm text-muted-foreground">
+                      <span className="flex items-center gap-1">
+                        <Calendar className="h-3 w-3" />
+                        {rat.date}
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <Clock className="h-3 w-3" />
+                        {rat.time}
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <MapPin className="h-3 w-3" />
+                        {rat.location}
+                      </span>
                     </div>
                   </div>
-                ))}
+                </div>
+
+                <div className="flex items-center gap-6">
+                  <div className="text-right">
+                    <p className="font-medium">
+                      {rat.attendees} / {rat.totalMembers} Anggota
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      {((rat.attendees / rat.totalMembers) * 100).toFixed(1)}%
+                      kehadiran
+                    </p>
+                  </div>
+
+                  <Badge
+                    variant={rat.status === "selesai" ? "default" : "secondary"}
+                  >
+                    {rat.status}
+                  </Badge>
+
+                  <Button variant="ghost" size="sm">
+                    Detail
+                  </Button>
+                </div>
               </div>
-            </CardContent>
-          </Card>
-        </div>
-      </DashboardLayout>
-    </ProtectedRoute>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/src/app/koperasi/shu/page.tsx
+++ b/src/app/koperasi/shu/page.tsx
@@ -1,7 +1,5 @@
 /** @format */
 
-import { ProtectedRoute } from "@/components/shared/protected-route";
-import { DashboardLayout } from "@/components/shared/dashboard-layout";
 import {
   Card,
   CardContent,
@@ -11,65 +9,7 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import {
-  BarChart3,
-  Users,
-  PiggyBank,
-  CreditCard,
-  TrendingUp,
-  Building,
-  Receipt,
-  FileText,
-  Settings,
-  MessageCircle,
-  DollarSign,
-  Calculator,
-  Download,
-  Calendar,
-} from "lucide-react";
-
-const koperasiNavigation = [
-  {
-    name: "Dashboard",
-    href: "/dashboard",
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    name: "Keanggotaan",
-    href: "/keanggotaan",
-    icon: <Users className="h-4 w-4" />,
-  },
-  {
-    name: "Simpanan",
-    href: "/simpanan",
-    icon: <PiggyBank className="h-4 w-4" />,
-  },
-  {
-    name: "Pinjaman",
-    href: "/pinjaman",
-    icon: <CreditCard className="h-4 w-4" />,
-  },
-  { name: "SHU", href: "/shu", icon: <TrendingUp className="h-4 w-4" /> },
-  { name: "RAT", href: "/rat", icon: <Calendar className="h-4 w-4" /> },
-  { name: "Aset", href: "/aset", icon: <Building className="h-4 w-4" /> },
-  {
-    name: "Transaksi",
-    href: "/transaksi",
-    icon: <Receipt className="h-4 w-4" />,
-  },
-  { name: "Laporan", href: "/laporan", icon: <FileText className="h-4 w-4" /> },
-  {
-    name: "Pengaturan",
-    href: "/pengaturan",
-    icon: <Settings className="h-4 w-4" />,
-  },
-  { name: "Tagihan", href: "/tagihan", icon: <Receipt className="h-4 w-4" /> },
-  {
-    name: "Chat Support",
-    href: "/chat-support",
-    icon: <MessageCircle className="h-4 w-4" />,
-  },
-];
+import { Users, DollarSign, Calculator, Download } from "lucide-react";
 
 const shuData = [
   {
@@ -121,179 +61,164 @@ const memberSHU = [
 
 export default function SHUPage() {
   return (
-    <ProtectedRoute requiredRole="koperasi">
-      <DashboardLayout
-        title="Sisa Hasil Usaha (SHU)"
-        navigation={koperasiNavigation}
-      >
-        <div className="space-y-6">
-          {/* Header */}
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-2xl font-bold">Sisa Hasil Usaha (SHU)</h2>
-              <p className="text-muted-foreground">
-                Kelola pembagian SHU kepada anggota
-              </p>
-            </div>
-            <div className="flex gap-2">
-              <Button variant="outline">
-                <Calculator className="h-4 w-4 mr-2" />
-                Hitung SHU
-              </Button>
-              <Button>
-                <Download className="h-4 w-4 mr-2" />
-                Export Data
-              </Button>
-            </div>
-          </div>
-
-          {/* SHU Summary */}
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Total SHU 2023
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">Rp 450M</div>
-                <p className="text-xs text-muted-foreground">
-                  +18.4% dari tahun sebelumnya
-                </p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Bagian Anggota
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">Rp 270M</div>
-                <p className="text-xs text-muted-foreground">
-                  60% dari total SHU
-                </p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Bagian Modal
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">Rp 180M</div>
-                <p className="text-xs text-muted-foreground">
-                  40% dari total SHU
-                </p>
-              </CardContent>
-            </Card>
-          </div>
-
-          {/* SHU History */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Riwayat SHU</CardTitle>
-              <CardDescription>Data SHU per tahun</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                {shuData.map((shu) => (
-                  <div
-                    key={shu.year}
-                    className="flex items-center justify-between p-4 border rounded-lg"
-                  >
-                    <div className="flex items-center gap-4">
-                      <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
-                        <DollarSign className="h-6 w-6" />
-                      </div>
-                      <div>
-                        <h3 className="font-medium">SHU Tahun {shu.year}</h3>
-                        <p className="text-sm text-muted-foreground">
-                          Total: {shu.totalSHU}
-                        </p>
-                      </div>
-                    </div>
-
-                    <div className="flex items-center gap-6">
-                      <div className="text-right">
-                        <p className="text-sm font-medium">
-                          Anggota: {shu.memberAmount} ({shu.memberShare})
-                        </p>
-                        <p className="text-sm text-muted-foreground">
-                          Modal: {shu.capitalAmount} ({shu.capitalShare})
-                        </p>
-                      </div>
-
-                      <Badge variant="default">{shu.status}</Badge>
-
-                      <Button variant="ghost" size="sm">
-                        Detail
-                      </Button>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Member SHU Distribution */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Pembagian SHU Anggota 2023</CardTitle>
-              <CardDescription>Detail SHU per anggota</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                {memberSHU.map((member) => (
-                  <div
-                    key={member.memberId}
-                    className="flex items-center justify-between p-4 border rounded-lg"
-                  >
-                    <div className="flex items-center gap-4">
-                      <div className="w-12 h-12 bg-muted rounded-full flex items-center justify-center">
-                        <Users className="h-6 w-6" />
-                      </div>
-                      <div>
-                        <h3 className="font-medium">{member.memberName}</h3>
-                        <p className="text-sm text-muted-foreground">
-                          ID: {member.memberId}
-                        </p>
-                      </div>
-                    </div>
-
-                    <div className="flex items-center gap-6">
-                      <div className="text-right">
-                        <p className="text-sm font-medium">
-                          Total SHU: {member.totalSHU}
-                        </p>
-                        <p className="text-sm text-muted-foreground">
-                          Transaksi: {member.transactionShare} • Modal:{" "}
-                          {member.capitalShare}
-                        </p>
-                      </div>
-
-                      <Badge
-                        variant={
-                          member.status === "dibayar" ? "default" : "secondary"
-                        }
-                      >
-                        {member.status === "dibayar"
-                          ? "Dibayar"
-                          : "Belum Dibayar"}
-                      </Badge>
-
-                      <Button variant="ghost" size="sm">
-                        Bayar
-                      </Button>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold">Sisa Hasil Usaha (SHU)</h2>
+          <p className="text-muted-foreground">
+            Kelola pembagian SHU kepada anggota
+          </p>
         </div>
-      </DashboardLayout>
-    </ProtectedRoute>
+        <div className="flex gap-2">
+          <Button variant="outline">
+            <Calculator className="h-4 w-4 mr-2" />
+            Hitung SHU
+          </Button>
+          <Button>
+            <Download className="h-4 w-4 mr-2" />
+            Export Data
+          </Button>
+        </div>
+      </div>
+
+      {/* SHU Summary */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">
+              Total SHU 2023
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">Rp 450M</div>
+            <p className="text-xs text-muted-foreground">
+              +18.4% dari tahun sebelumnya
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">
+              Bagian Anggota
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">Rp 270M</div>
+            <p className="text-xs text-muted-foreground">60% dari total SHU</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">Bagian Modal</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">Rp 180M</div>
+            <p className="text-xs text-muted-foreground">40% dari total SHU</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* SHU History */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Riwayat SHU</CardTitle>
+          <CardDescription>Data SHU per tahun</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {shuData.map((shu) => (
+              <div
+                key={shu.year}
+                className="flex items-center justify-between p-4 border rounded-lg"
+              >
+                <div className="flex items-center gap-4">
+                  <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
+                    <DollarSign className="h-6 w-6" />
+                  </div>
+                  <div>
+                    <h3 className="font-medium">SHU Tahun {shu.year}</h3>
+                    <p className="text-sm text-muted-foreground">
+                      Total: {shu.totalSHU}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-6">
+                  <div className="text-right">
+                    <p className="text-sm font-medium">
+                      Anggota: {shu.memberAmount} ({shu.memberShare})
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      Modal: {shu.capitalAmount} ({shu.capitalShare})
+                    </p>
+                  </div>
+
+                  <Badge variant="default">{shu.status}</Badge>
+
+                  <Button variant="ghost" size="sm">
+                    Detail
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Member SHU Distribution */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Pembagian SHU Anggota 2023</CardTitle>
+          <CardDescription>Detail SHU per anggota</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {memberSHU.map((member) => (
+              <div
+                key={member.memberId}
+                className="flex items-center justify-between p-4 border rounded-lg"
+              >
+                <div className="flex items-center gap-4">
+                  <div className="w-12 h-12 bg-muted rounded-full flex items-center justify-center">
+                    <Users className="h-6 w-6" />
+                  </div>
+                  <div>
+                    <h3 className="font-medium">{member.memberName}</h3>
+                    <p className="text-sm text-muted-foreground">
+                      ID: {member.memberId}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-6">
+                  <div className="text-right">
+                    <p className="text-sm font-medium">
+                      Total SHU: {member.totalSHU}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      Transaksi: {member.transactionShare} • Modal:{" "}
+                      {member.capitalShare}
+                    </p>
+                  </div>
+
+                  <Badge
+                    variant={
+                      member.status === "dibayar" ? "default" : "secondary"
+                    }
+                  >
+                    {member.status === "dibayar" ? "Dibayar" : "Belum Dibayar"}
+                  </Badge>
+
+                  <Button variant="ghost" size="sm">
+                    Bayar
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/src/app/koperasi/simpanan/page.tsx
+++ b/src/app/koperasi/simpanan/page.tsx
@@ -1,7 +1,5 @@
 /** @format */
 
-import { ProtectedRoute } from "@/components/shared/protected-route";
-import { DashboardLayout } from "@/components/shared/dashboard-layout";
 import {
   Card,
   CardContent,
@@ -12,65 +10,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import {
-  BarChart3,
-  Users,
-  PiggyBank,
-  CreditCard,
-  TrendingUp,
-  Building,
-  Receipt,
-  FileText,
-  Settings,
-  MessageCircle,
-  Search,
-  ArrowUpCircle,
-  ArrowDownCircle,
-  Calendar,
-} from "lucide-react";
-
-const koperasiNavigation = [
-  {
-    name: "Dashboard",
-    href: "/dashboard",
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    name: "Keanggotaan",
-    href: "/keanggotaan",
-    icon: <Users className="h-4 w-4" />,
-  },
-  {
-    name: "Simpanan",
-    href: "/simpanan",
-    icon: <PiggyBank className="h-4 w-4" />,
-  },
-  {
-    name: "Pinjaman",
-    href: "/pinjaman",
-    icon: <CreditCard className="h-4 w-4" />,
-  },
-  { name: "SHU", href: "/shu", icon: <TrendingUp className="h-4 w-4" /> },
-  { name: "RAT", href: "/rat", icon: <Calendar className="h-4 w-4" /> },
-  { name: "Aset", href: "/aset", icon: <Building className="h-4 w-4" /> },
-  {
-    name: "Transaksi",
-    href: "/transaksi",
-    icon: <Receipt className="h-4 w-4" />,
-  },
-  { name: "Laporan", href: "/laporan", icon: <FileText className="h-4 w-4" /> },
-  {
-    name: "Pengaturan",
-    href: "/pengaturan",
-    icon: <Settings className="h-4 w-4" />,
-  },
-  { name: "Tagihan", href: "/tagihan", icon: <Receipt className="h-4 w-4" /> },
-  {
-    name: "Chat Support",
-    href: "/chat-support",
-    icon: <MessageCircle className="h-4 w-4" />,
-  },
-];
+import { Search, ArrowUpCircle, ArrowDownCircle } from "lucide-react";
 
 const simpananTransactions = [
   {
@@ -107,174 +47,163 @@ const simpananTransactions = [
 
 export default function SimpananPage() {
   return (
-    <ProtectedRoute requiredRole="koperasi">
-      <DashboardLayout
-        title="Manajemen Simpanan"
-        navigation={koperasiNavigation}
-      >
-        <div className="space-y-6">
-          {/* Header */}
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-2xl font-bold">Simpanan</h2>
-              <p className="text-muted-foreground">
-                Kelola simpanan anggota koperasi
-              </p>
-            </div>
-            <div className="flex gap-2">
-              <Button variant="outline">
-                <ArrowDownCircle className="h-4 w-4 mr-2" />
-                Penarikan
-              </Button>
-              <Button>
-                <ArrowUpCircle className="h-4 w-4 mr-2" />
-                Setoran
-              </Button>
-            </div>
-          </div>
-
-          {/* Stats */}
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Total Simpanan
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">Rp 2.4M</div>
-                <p className="text-xs text-muted-foreground">
-                  +15.2% dari bulan lalu
-                </p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Simpanan Pokok
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">Rp 623K</div>
-                <p className="text-xs text-muted-foreground">1,247 anggota</p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Simpanan Wajib
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">Rp 1.2M</div>
-                <p className="text-xs text-muted-foreground">Bulanan</p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Simpanan Sukarela
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">Rp 577K</div>
-                <p className="text-xs text-muted-foreground">
-                  Dapat ditarik sewaktu-waktu
-                </p>
-              </CardContent>
-            </Card>
-          </div>
-
-          {/* Search */}
-          <Card>
-            <CardContent className="pt-6">
-              <div className="flex items-center gap-4">
-                <div className="relative flex-1">
-                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                  <Input
-                    placeholder="Cari transaksi simpanan..."
-                    className="pl-10"
-                  />
-                </div>
-                <Button variant="outline">Filter</Button>
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Transactions Table */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Transaksi Simpanan</CardTitle>
-              <CardDescription>
-                Riwayat setoran dan penarikan simpanan
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                {simpananTransactions.map((transaction) => (
-                  <div
-                    key={transaction.id}
-                    className="flex items-center justify-between p-4 border rounded-lg"
-                  >
-                    <div className="flex items-center gap-4">
-                      <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
-                        {transaction.type === "setoran" ? (
-                          <ArrowUpCircle className="h-6 w-6 text-green-600" />
-                        ) : (
-                          <ArrowDownCircle className="h-6 w-6 text-red-600" />
-                        )}
-                      </div>
-                      <div>
-                        <h3 className="font-medium">
-                          {transaction.memberName}
-                        </h3>
-                        <p className="text-sm text-muted-foreground">
-                          {transaction.memberId} • {transaction.category}
-                        </p>
-                        <p className="text-sm text-muted-foreground">
-                          {transaction.date}
-                        </p>
-                      </div>
-                    </div>
-
-                    <div className="flex items-center gap-6">
-                      <div className="text-right">
-                        <p
-                          className={`font-medium ${
-                            transaction.type === "setoran"
-                              ? "text-green-600"
-                              : "text-red-600"
-                          }`}
-                        >
-                          {transaction.type === "setoran" ? "+" : "-"}
-                          {transaction.amount}
-                        </p>
-                        <p className="text-sm text-muted-foreground">
-                          Saldo: {transaction.balance}
-                        </p>
-                      </div>
-
-                      <Badge
-                        variant={
-                          transaction.type === "setoran"
-                            ? "default"
-                            : "secondary"
-                        }
-                      >
-                        {transaction.type}
-                      </Badge>
-
-                      <Button variant="ghost" size="sm">
-                        Detail
-                      </Button>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold">Simpanan</h2>
+          <p className="text-muted-foreground">
+            Kelola simpanan anggota koperasi
+          </p>
         </div>
-      </DashboardLayout>
-    </ProtectedRoute>
+        <div className="flex gap-2">
+          <Button variant="outline">
+            <ArrowDownCircle className="h-4 w-4 mr-2" />
+            Penarikan
+          </Button>
+          <Button>
+            <ArrowUpCircle className="h-4 w-4 mr-2" />
+            Setoran
+          </Button>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">
+              Total Simpanan
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">Rp 2.4M</div>
+            <p className="text-xs text-muted-foreground">
+              +15.2% dari bulan lalu
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">
+              Simpanan Pokok
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">Rp 623K</div>
+            <p className="text-xs text-muted-foreground">1,247 anggota</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">
+              Simpanan Wajib
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">Rp 1.2M</div>
+            <p className="text-xs text-muted-foreground">Bulanan</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">
+              Simpanan Sukarela
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">Rp 577K</div>
+            <p className="text-xs text-muted-foreground">
+              Dapat ditarik sewaktu-waktu
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Search */}
+      <Card>
+        <CardContent className="pt-6">
+          <div className="flex items-center gap-4">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Cari transaksi simpanan..."
+                className="pl-10"
+              />
+            </div>
+            <Button variant="outline">Filter</Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Transactions Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Transaksi Simpanan</CardTitle>
+          <CardDescription>
+            Riwayat setoran dan penarikan simpanan
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {simpananTransactions.map((transaction) => (
+              <div
+                key={transaction.id}
+                className="flex items-center justify-between p-4 border rounded-lg"
+              >
+                <div className="flex items-center gap-4">
+                  <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
+                    {transaction.type === "setoran" ? (
+                      <ArrowUpCircle className="h-6 w-6 text-green-600" />
+                    ) : (
+                      <ArrowDownCircle className="h-6 w-6 text-red-600" />
+                    )}
+                  </div>
+                  <div>
+                    <h3 className="font-medium">{transaction.memberName}</h3>
+                    <p className="text-sm text-muted-foreground">
+                      {transaction.memberId} • {transaction.category}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      {transaction.date}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-6">
+                  <div className="text-right">
+                    <p
+                      className={`font-medium ${
+                        transaction.type === "setoran"
+                          ? "text-green-600"
+                          : "text-red-600"
+                      }`}
+                    >
+                      {transaction.type === "setoran" ? "+" : "-"}
+                      {transaction.amount}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      Saldo: {transaction.balance}
+                    </p>
+                  </div>
+
+                  <Badge
+                    variant={
+                      transaction.type === "setoran" ? "default" : "secondary"
+                    }
+                  >
+                    {transaction.type}
+                  </Badge>
+
+                  <Button variant="ghost" size="sm">
+                    Detail
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/src/app/umkm/dashboard/page.tsx
+++ b/src/app/umkm/dashboard/page.tsx
@@ -1,7 +1,5 @@
 /** @format */
 
-import { DashboardLayout } from "@/components/shared/dashboard-layout";
-import { ProtectedRoute } from "@/components/shared/protected-route";
 import {
   Card,
   CardContent,
@@ -10,41 +8,14 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import {
-  BarChart3,
   Package,
   ShoppingCart,
   TrendingUp,
   DollarSign,
   AlertTriangle,
-  Settings,
   FileText,
   Calculator,
 } from "lucide-react";
-
-const umkmNavigation = [
-  {
-    name: "Dashboard",
-    href: "/dashboard",
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    name: "Inventaris",
-    href: "/inventaris",
-    icon: <Package className="h-4 w-4" />,
-  },
-  {
-    name: "Harga Bertingkat",
-    href: "/harga-bertingkat",
-    icon: <Calculator className="h-4 w-4" />,
-  },
-  { name: "POS", href: "/pos", icon: <ShoppingCart className="h-4 w-4" /> },
-  { name: "Laporan", href: "/laporan", icon: <FileText className="h-4 w-4" /> },
-  {
-    name: "Pengaturan",
-    href: "/pengaturan",
-    icon: <Settings className="h-4 w-4" />,
-  },
-];
 
 const dashboardStats = [
   {
@@ -79,200 +50,191 @@ const dashboardStats = [
 
 export default function UMKMDashboard() {
   return (
-    <ProtectedRoute requiredRole="umkm">
-      <DashboardLayout title="Dashboard UMKM" navigation={umkmNavigation}>
-        <div className="space-y-6">
-          {/* Stats Cards */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {dashboardStats.map((stat) => (
-              <Card key={stat.title}>
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                  <CardTitle className="text-sm font-medium">
-                    {stat.title}
-                  </CardTitle>
-                  {stat.icon}
-                </CardHeader>
-                <CardContent>
-                  <div className="text-2xl font-bold">{stat.value}</div>
-                  <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                    <TrendingUp
-                      className={`h-3 w-3 ${
-                        stat.trend === "up" ? "text-green-500" : "text-red-500"
-                      }`}
-                    />
-                    <span
-                      className={
-                        stat.trend === "up" ? "text-green-500" : "text-red-500"
-                      }
-                    >
-                      {stat.change}
-                    </span>
-                    <span>dari kemarin</span>
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-
-          {/* Recent Activity */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <Card>
-              <CardHeader>
-                <CardTitle>Transaksi Terbaru</CardTitle>
-                <CardDescription>Penjualan hari ini</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-4">
-                  {[
-                    {
-                      customer: "Pelanggan Reguler",
-                      items: "Kopi Arabica x2, Roti Bakar x1",
-                      amount: "Rp 45,000",
-                      time: "10:30",
-                    },
-                    {
-                      customer: "Pelanggan Baru",
-                      items: "Nasi Gudeg x1, Es Teh x1",
-                      amount: "Rp 25,000",
-                      time: "11:15",
-                    },
-                    {
-                      customer: "Pelanggan VIP",
-                      items: "Paket Hemat x3",
-                      amount: "Rp 120,000",
-                      time: "12:00",
-                    },
-                  ].map((transaction, index) => (
-                    <div
-                      key={index}
-                      className="flex items-center justify-between"
-                    >
-                      <div>
-                        <p className="font-medium">{transaction.customer}</p>
-                        <p className="text-sm text-muted-foreground">
-                          {transaction.items}
-                        </p>
-                      </div>
-                      <div className="text-right">
-                        <p className="font-medium">{transaction.amount}</p>
-                        <p className="text-sm text-muted-foreground">
-                          {transaction.time}
-                        </p>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle>Aksi Cepat</CardTitle>
-                <CardDescription>Fitur yang sering digunakan</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="grid grid-cols-2 gap-4">
-                  <a
-                    href="/pos"
-                    className="p-4 border rounded-lg hover:bg-muted transition-colors"
-                  >
-                    <ShoppingCart className="h-6 w-6 mb-2" />
-                    <p className="font-medium">Buka POS</p>
-                    <p className="text-sm text-muted-foreground">
-                      Mulai transaksi
-                    </p>
-                  </a>
-                  <a
-                    href="/inventaris"
-                    className="p-4 border rounded-lg hover:bg-muted transition-colors"
-                  >
-                    <Package className="h-6 w-6 mb-2" />
-                    <p className="font-medium">Tambah Produk</p>
-                    <p className="text-sm text-muted-foreground">
-                      Kelola inventaris
-                    </p>
-                  </a>
-                  <a
-                    href="/harga-bertingkat"
-                    className="p-4 border rounded-lg hover:bg-muted transition-colors"
-                  >
-                    <Calculator className="h-6 w-6 mb-2" />
-                    <p className="font-medium">Atur Harga</p>
-                    <p className="text-sm text-muted-foreground">
-                      Harga bertingkat
-                    </p>
-                  </a>
-                  <a
-                    href="/laporan"
-                    className="p-4 border rounded-lg hover:bg-muted transition-colors"
-                  >
-                    <FileText className="h-6 w-6 mb-2" />
-                    <p className="font-medium">Laporan</p>
-                    <p className="text-sm text-muted-foreground">
-                      Analisis penjualan
-                    </p>
-                  </a>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-
-          {/* Low Stock Alert */}
-          <Card className="border-yellow-200">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <AlertTriangle className="h-5 w-5 text-yellow-600" />
-                Peringatan Stok
+    <div className="space-y-6">
+      {/* Stats Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        {dashboardStats.map((stat) => (
+          <Card key={stat.title}>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">
+                {stat.title}
               </CardTitle>
-              <CardDescription>Produk dengan stok menipis</CardDescription>
+              {stat.icon}
             </CardHeader>
             <CardContent>
-              <div className="space-y-3">
-                {[
-                  {
-                    product: "Kopi Arabica Premium",
-                    stock: 5,
-                    minStock: 10,
-                    category: "Minuman",
-                  },
-                  {
-                    product: "Roti Bakar Spesial",
-                    stock: 3,
-                    minStock: 15,
-                    category: "Makanan",
-                  },
-                  {
-                    product: "Es Krim Vanilla",
-                    stock: 2,
-                    minStock: 8,
-                    category: "Dessert",
-                  },
-                ].map((item, index) => (
-                  <div
-                    key={index}
-                    className="flex items-center justify-between p-3 bg-yellow-50 rounded-lg"
-                  >
-                    <div>
-                      <p className="font-medium">{item.product}</p>
-                      <p className="text-sm text-muted-foreground">
-                        {item.category}
-                      </p>
-                    </div>
-                    <div className="text-right">
-                      <p className="font-medium text-yellow-700">
-                        Stok: {item.stock}
-                      </p>
-                      <p className="text-sm text-muted-foreground">
-                        Min: {item.minStock}
-                      </p>
-                    </div>
-                  </div>
-                ))}
+              <div className="text-2xl font-bold">{stat.value}</div>
+              <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                <TrendingUp
+                  className={`h-3 w-3 ${
+                    stat.trend === "up" ? "text-green-500" : "text-red-500"
+                  }`}
+                />
+                <span
+                  className={
+                    stat.trend === "up" ? "text-green-500" : "text-red-500"
+                  }
+                >
+                  {stat.change}
+                </span>
+                <span>dari kemarin</span>
               </div>
             </CardContent>
           </Card>
-        </div>
-      </DashboardLayout>
-    </ProtectedRoute>
+        ))}
+      </div>
+
+      {/* Recent Activity */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Transaksi Terbaru</CardTitle>
+            <CardDescription>Penjualan hari ini</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              {[
+                {
+                  customer: "Pelanggan Reguler",
+                  items: "Kopi Arabica x2, Roti Bakar x1",
+                  amount: "Rp 45,000",
+                  time: "10:30",
+                },
+                {
+                  customer: "Pelanggan Baru",
+                  items: "Nasi Gudeg x1, Es Teh x1",
+                  amount: "Rp 25,000",
+                  time: "11:15",
+                },
+                {
+                  customer: "Pelanggan VIP",
+                  items: "Paket Hemat x3",
+                  amount: "Rp 120,000",
+                  time: "12:00",
+                },
+              ].map((transaction, index) => (
+                <div key={index} className="flex items-center justify-between">
+                  <div>
+                    <p className="font-medium">{transaction.customer}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {transaction.items}
+                    </p>
+                  </div>
+                  <div className="text-right">
+                    <p className="font-medium">{transaction.amount}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {transaction.time}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Aksi Cepat</CardTitle>
+            <CardDescription>Fitur yang sering digunakan</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-2 gap-4">
+              <a
+                href="/pos"
+                className="p-4 border rounded-lg hover:bg-muted transition-colors"
+              >
+                <ShoppingCart className="h-6 w-6 mb-2" />
+                <p className="font-medium">Buka POS</p>
+                <p className="text-sm text-muted-foreground">Mulai transaksi</p>
+              </a>
+              <a
+                href="/inventaris"
+                className="p-4 border rounded-lg hover:bg-muted transition-colors"
+              >
+                <Package className="h-6 w-6 mb-2" />
+                <p className="font-medium">Tambah Produk</p>
+                <p className="text-sm text-muted-foreground">
+                  Kelola inventaris
+                </p>
+              </a>
+              <a
+                href="/harga-bertingkat"
+                className="p-4 border rounded-lg hover:bg-muted transition-colors"
+              >
+                <Calculator className="h-6 w-6 mb-2" />
+                <p className="font-medium">Atur Harga</p>
+                <p className="text-sm text-muted-foreground">
+                  Harga bertingkat
+                </p>
+              </a>
+              <a
+                href="/laporan"
+                className="p-4 border rounded-lg hover:bg-muted transition-colors"
+              >
+                <FileText className="h-6 w-6 mb-2" />
+                <p className="font-medium">Laporan</p>
+                <p className="text-sm text-muted-foreground">
+                  Analisis penjualan
+                </p>
+              </a>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Low Stock Alert */}
+      <Card className="border-yellow-200">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-yellow-600" />
+            Peringatan Stok
+          </CardTitle>
+          <CardDescription>Produk dengan stok menipis</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {[
+              {
+                product: "Kopi Arabica Premium",
+                stock: 5,
+                minStock: 10,
+                category: "Minuman",
+              },
+              {
+                product: "Roti Bakar Spesial",
+                stock: 3,
+                minStock: 15,
+                category: "Makanan",
+              },
+              {
+                product: "Es Krim Vanilla",
+                stock: 2,
+                minStock: 8,
+                category: "Dessert",
+              },
+            ].map((item, index) => (
+              <div
+                key={index}
+                className="flex items-center justify-between p-3 bg-yellow-50 rounded-lg"
+              >
+                <div>
+                  <p className="font-medium">{item.product}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {item.category}
+                  </p>
+                </div>
+                <div className="text-right">
+                  <p className="font-medium text-yellow-700">
+                    Stok: {item.stock}
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    Min: {item.minStock}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/src/app/umkm/harga-bertingkat/page.tsx
+++ b/src/app/umkm/harga-bertingkat/page.tsx
@@ -1,7 +1,5 @@
 /** @format */
 
-import { ProtectedRoute } from "@/components/shared/protected-route";
-import { DashboardLayout } from "@/components/shared/dashboard-layout";
 import {
   Card,
   CardContent,
@@ -12,45 +10,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import {
-  BarChart3,
-  Package,
-  ShoppingCart,
-  Settings,
-  FileText,
-  Calculator,
-  Plus,
-  Search,
-  Edit,
-  Crown,
-  Star,
-  User,
-} from "lucide-react";
-
-const umkmNavigation = [
-  {
-    name: "Dashboard",
-    href: "/dashboard",
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    name: "Inventaris",
-    href: "/inventaris",
-    icon: <Package className="h-4 w-4" />,
-  },
-  {
-    name: "Harga Bertingkat",
-    href: "/harga-bertingkat",
-    icon: <Calculator className="h-4 w-4" />,
-  },
-  { name: "POS", href: "/pos", icon: <ShoppingCart className="h-4 w-4" /> },
-  { name: "Laporan", href: "/laporan", icon: <FileText className="h-4 w-4" /> },
-  {
-    name: "Pengaturan",
-    href: "/pengaturan",
-    icon: <Settings className="h-4 w-4" />,
-  },
-];
+import { Package, Plus, Search, Edit, Crown, Star, User } from "lucide-react";
 
 const customerTiers = [
   {
@@ -132,135 +92,125 @@ const productPricing = [
 
 export default function HargaBertingkatPage() {
   return (
-    <ProtectedRoute requiredRole="umkm">
-      <DashboardLayout title="Harga Bertingkat" navigation={umkmNavigation}>
-        <div className="space-y-6">
-          {/* Header */}
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-2xl font-bold">Harga Bertingkat</h2>
-              <p className="text-muted-foreground">
-                Kelola harga berdasarkan tingkat pelanggan
-              </p>
-            </div>
-            <Button>
-              <Plus className="h-4 w-4 mr-2" />
-              Tambah Tingkat
-            </Button>
-          </div>
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold">Harga Bertingkat</h2>
+          <p className="text-muted-foreground">
+            Kelola harga berdasarkan tingkat pelanggan
+          </p>
+        </div>
+        <Button>
+          <Plus className="h-4 w-4 mr-2" />
+          Tambah Tingkat
+        </Button>
+      </div>
 
-          {/* Customer Tiers */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {customerTiers.map((tier) => (
-              <Card key={tier.id}>
-                <CardHeader>
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                      <div className={`p-2 rounded-lg ${tier.color}`}>
-                        {tier.icon}
-                      </div>
-                      <CardTitle className="text-sm">{tier.name}</CardTitle>
+      {/* Customer Tiers */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        {customerTiers.map((tier) => (
+          <Card key={tier.id}>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <div className={`p-2 rounded-lg ${tier.color}`}>
+                    {tier.icon}
+                  </div>
+                  <CardTitle className="text-sm">{tier.name}</CardTitle>
+                </div>
+                <Button variant="ghost" size="icon">
+                  <Edit className="h-4 w-4" />
+                </Button>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <div>
+                <p className="text-sm text-muted-foreground">Min. Pembelian</p>
+                <p className="font-medium">{tier.minPurchase}</p>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Diskon</p>
+                <p className="font-medium">{tier.discount}</p>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Anggota</p>
+                <p className="font-medium">{tier.members} orang</p>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Search */}
+      <Card>
+        <CardContent className="pt-6">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input placeholder="Cari produk..." className="pl-10" />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Product Pricing Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Daftar Harga Produk</CardTitle>
+          <CardDescription>
+            Harga produk berdasarkan tingkat pelanggan
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {productPricing.map((product) => (
+              <div key={product.id} className="p-4 border rounded-lg">
+                <div className="flex items-center justify-between mb-4">
+                  <div className="flex items-center gap-4">
+                    <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
+                      <Package className="h-6 w-6" />
                     </div>
+                    <div>
+                      <h3 className="font-medium">{product.name}</h3>
+                      <p className="text-sm text-muted-foreground">
+                        {product.id} • {product.category}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Badge variant="outline">
+                      Harga Dasar: {product.basePrice}
+                    </Badge>
                     <Button variant="ghost" size="icon">
                       <Edit className="h-4 w-4" />
                     </Button>
                   </div>
-                </CardHeader>
-                <CardContent className="space-y-2">
-                  <div>
-                    <p className="text-sm text-muted-foreground">
-                      Min. Pembelian
-                    </p>
-                    <p className="font-medium">{tier.minPurchase}</p>
-                  </div>
-                  <div>
-                    <p className="text-sm text-muted-foreground">Diskon</p>
-                    <p className="font-medium">{tier.discount}</p>
-                  </div>
-                  <div>
-                    <p className="text-sm text-muted-foreground">Anggota</p>
-                    <p className="font-medium">{tier.members} orang</p>
-                  </div>
-                </CardContent>
-              </Card>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+                  {customerTiers.map((tier) => (
+                    <div key={tier.id} className="p-3 bg-muted rounded-lg">
+                      <div className="flex items-center gap-2 mb-2">
+                        <div className={`p-1 rounded ${tier.color}`}>
+                          {tier.icon}
+                        </div>
+                        <p className="text-sm font-medium">{tier.name}</p>
+                      </div>
+                      <p className="text-lg font-bold">
+                        {product.prices[tier.id as keyof typeof product.prices]}
+                      </p>
+                      {tier.discount !== "0%" && (
+                        <p className="text-sm text-green-600">
+                          Hemat {tier.discount}
+                        </p>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
             ))}
           </div>
-
-          {/* Search */}
-          <Card>
-            <CardContent className="pt-6">
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                <Input placeholder="Cari produk..." className="pl-10" />
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Product Pricing Table */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Daftar Harga Produk</CardTitle>
-              <CardDescription>
-                Harga produk berdasarkan tingkat pelanggan
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                {productPricing.map((product) => (
-                  <div key={product.id} className="p-4 border rounded-lg">
-                    <div className="flex items-center justify-between mb-4">
-                      <div className="flex items-center gap-4">
-                        <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
-                          <Package className="h-6 w-6" />
-                        </div>
-                        <div>
-                          <h3 className="font-medium">{product.name}</h3>
-                          <p className="text-sm text-muted-foreground">
-                            {product.id} • {product.category}
-                          </p>
-                        </div>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <Badge variant="outline">
-                          Harga Dasar: {product.basePrice}
-                        </Badge>
-                        <Button variant="ghost" size="icon">
-                          <Edit className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    </div>
-
-                    <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-                      {customerTiers.map((tier) => (
-                        <div key={tier.id} className="p-3 bg-muted rounded-lg">
-                          <div className="flex items-center gap-2 mb-2">
-                            <div className={`p-1 rounded ${tier.color}`}>
-                              {tier.icon}
-                            </div>
-                            <p className="text-sm font-medium">{tier.name}</p>
-                          </div>
-                          <p className="text-lg font-bold">
-                            {
-                              product.prices[
-                                tier.id as keyof typeof product.prices
-                              ]
-                            }
-                          </p>
-                          {tier.discount !== "0%" && (
-                            <p className="text-sm text-green-600">
-                              Hemat {tier.discount}
-                            </p>
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-      </DashboardLayout>
-    </ProtectedRoute>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/src/app/umkm/inventaris/page.tsx
+++ b/src/app/umkm/inventaris/page.tsx
@@ -1,7 +1,5 @@
 /** @format */
 
-import { ProtectedRoute } from "@/components/shared/protected-route";
-import { DashboardLayout } from "@/components/shared/dashboard-layout";
 import {
   Card,
   CardContent,
@@ -13,43 +11,13 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import {
-  BarChart3,
   Package,
-  ShoppingCart,
-  Settings,
-  FileText,
-  Calculator,
   Plus,
   Search,
   Edit,
   Trash2,
   AlertTriangle,
 } from "lucide-react";
-
-const umkmNavigation = [
-  {
-    name: "Dashboard",
-    href: "/dashboard",
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    name: "Inventaris",
-    href: "/inventaris",
-    icon: <Package className="h-4 w-4" />,
-  },
-  {
-    name: "Harga Bertingkat",
-    href: "/harga-bertingkat",
-    icon: <Calculator className="h-4 w-4" />,
-  },
-  { name: "POS", href: "/pos", icon: <ShoppingCart className="h-4 w-4" /> },
-  { name: "Laporan", href: "/laporan", icon: <FileText className="h-4 w-4" /> },
-  {
-    name: "Pengaturan",
-    href: "/pengaturan",
-    icon: <Settings className="h-4 w-4" />,
-  },
-];
 
 const products = [
   {
@@ -96,164 +64,148 @@ const products = [
 
 export default function InventarisPage() {
   return (
-    <ProtectedRoute requiredRole="umkm">
-      <DashboardLayout title="Manajemen Inventaris" navigation={umkmNavigation}>
-        <div className="space-y-6">
-          {/* Header */}
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-2xl font-bold">Inventaris</h2>
-              <p className="text-muted-foreground">
-                Kelola stok dan produk UMKM
-              </p>
-            </div>
-            <Button>
-              <Plus className="h-4 w-4 mr-2" />
-              Tambah Produk
-            </Button>
-          </div>
-
-          {/* Stats */}
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Total Produk
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">156</div>
-                <p className="text-xs text-muted-foreground">+8 produk baru</p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Stok Tersedia
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">142</div>
-                <p className="text-xs text-muted-foreground">91% dari total</p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Stok Rendah
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold text-yellow-600">9</div>
-                <p className="text-xs text-muted-foreground">Perlu restok</p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">
-                  Stok Habis
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold text-red-600">5</div>
-                <p className="text-xs text-muted-foreground">Segera restok</p>
-              </CardContent>
-            </Card>
-          </div>
-
-          {/* Search and Filters */}
-          <Card>
-            <CardContent className="pt-6">
-              <div className="flex items-center gap-4">
-                <div className="relative flex-1">
-                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                  <Input placeholder="Cari produk..." className="pl-10" />
-                </div>
-                <Button variant="outline">Filter Kategori</Button>
-                <Button variant="outline">Filter Status</Button>
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Products Table */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Daftar Produk</CardTitle>
-              <CardDescription>
-                Kelola inventaris dan stok produk
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                {products.map((product) => (
-                  <div
-                    key={product.id}
-                    className="flex items-center justify-between p-4 border rounded-lg"
-                  >
-                    <div className="flex items-center gap-4">
-                      <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
-                        <Package className="h-6 w-6" />
-                      </div>
-                      <div>
-                        <h3 className="font-medium">{product.name}</h3>
-                        <p className="text-sm text-muted-foreground">
-                          {product.id} • {product.category}
-                        </p>
-                      </div>
-                    </div>
-
-                    <div className="flex items-center gap-6">
-                      <div className="text-right">
-                        <p className="font-medium">Stok: {product.stock}</p>
-                        <p className="text-sm text-muted-foreground">
-                          Min: {product.minStock}
-                        </p>
-                      </div>
-
-                      <div className="text-right">
-                        <p className="font-medium">{product.price}</p>
-                        <p className="text-sm text-muted-foreground">
-                          HPP: {product.cost}
-                        </p>
-                      </div>
-
-                      <div className="flex items-center gap-2">
-                        {product.status === "stok_rendah" && (
-                          <AlertTriangle className="h-4 w-4 text-yellow-600" />
-                        )}
-                        <Badge
-                          variant={
-                            product.status === "tersedia"
-                              ? "default"
-                              : product.status === "stok_rendah"
-                              ? "secondary"
-                              : "destructive"
-                          }
-                        >
-                          {product.status === "tersedia"
-                            ? "Tersedia"
-                            : product.status === "stok_rendah"
-                            ? "Stok Rendah"
-                            : "Habis"}
-                        </Badge>
-                      </div>
-
-                      <div className="flex items-center gap-2">
-                        <Button variant="ghost" size="icon">
-                          <Edit className="h-4 w-4" />
-                        </Button>
-                        <Button variant="ghost" size="icon">
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold">Inventaris</h2>
+          <p className="text-muted-foreground">Kelola stok dan produk UMKM</p>
         </div>
-      </DashboardLayout>
-    </ProtectedRoute>
+        <Button>
+          <Plus className="h-4 w-4 mr-2" />
+          Tambah Produk
+        </Button>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">Total Produk</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">156</div>
+            <p className="text-xs text-muted-foreground">+8 produk baru</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">Stok Tersedia</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">142</div>
+            <p className="text-xs text-muted-foreground">91% dari total</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">Stok Rendah</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-yellow-600">9</div>
+            <p className="text-xs text-muted-foreground">Perlu restok</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">Stok Habis</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-red-600">5</div>
+            <p className="text-xs text-muted-foreground">Segera restok</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Search and Filters */}
+      <Card>
+        <CardContent className="pt-6">
+          <div className="flex items-center gap-4">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input placeholder="Cari produk..." className="pl-10" />
+            </div>
+            <Button variant="outline">Filter Kategori</Button>
+            <Button variant="outline">Filter Status</Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Products Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Daftar Produk</CardTitle>
+          <CardDescription>Kelola inventaris dan stok produk</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {products.map((product) => (
+              <div
+                key={product.id}
+                className="flex items-center justify-between p-4 border rounded-lg"
+              >
+                <div className="flex items-center gap-4">
+                  <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
+                    <Package className="h-6 w-6" />
+                  </div>
+                  <div>
+                    <h3 className="font-medium">{product.name}</h3>
+                    <p className="text-sm text-muted-foreground">
+                      {product.id} • {product.category}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-6">
+                  <div className="text-right">
+                    <p className="font-medium">Stok: {product.stock}</p>
+                    <p className="text-sm text-muted-foreground">
+                      Min: {product.minStock}
+                    </p>
+                  </div>
+
+                  <div className="text-right">
+                    <p className="font-medium">{product.price}</p>
+                    <p className="text-sm text-muted-foreground">
+                      HPP: {product.cost}
+                    </p>
+                  </div>
+
+                  <div className="flex items-center gap-2">
+                    {product.status === "stok_rendah" && (
+                      <AlertTriangle className="h-4 w-4 text-yellow-600" />
+                    )}
+                    <Badge
+                      variant={
+                        product.status === "tersedia"
+                          ? "default"
+                          : product.status === "stok_rendah"
+                            ? "secondary"
+                            : "destructive"
+                      }
+                    >
+                      {product.status === "tersedia"
+                        ? "Tersedia"
+                        : product.status === "stok_rendah"
+                          ? "Stok Rendah"
+                          : "Habis"}
+                    </Badge>
+                  </div>
+
+                  <div className="flex items-center gap-2">
+                    <Button variant="ghost" size="icon">
+                      <Edit className="h-4 w-4" />
+                    </Button>
+                    <Button variant="ghost" size="icon">
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/src/app/umkm/laporan/page.tsx
+++ b/src/app/umkm/laporan/page.tsx
@@ -1,7 +1,5 @@
 /** @format */
 
-import { ProtectedRoute } from "@/components/shared/protected-route";
-import { DashboardLayout } from "@/components/shared/dashboard-layout";
 import {
   Card,
   CardContent,
@@ -11,42 +9,7 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import {
-  BarChart3,
-  Package,
-  ShoppingCart,
-  Settings,
-  FileText,
-  Calculator,
-  Download,
-  TrendingUp,
-  TrendingDown,
-} from "lucide-react";
-
-const umkmNavigation = [
-  {
-    name: "Dashboard",
-    href: "/dashboard",
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    name: "Inventaris",
-    href: "/inventaris",
-    icon: <Package className="h-4 w-4" />,
-  },
-  {
-    name: "Harga Bertingkat",
-    href: "/harga-bertingkat",
-    icon: <Calculator className="h-4 w-4" />,
-  },
-  { name: "POS", href: "/pos", icon: <ShoppingCart className="h-4 w-4" /> },
-  { name: "Laporan", href: "/laporan", icon: <FileText className="h-4 w-4" /> },
-  {
-    name: "Pengaturan",
-    href: "/pengaturan",
-    icon: <Settings className="h-4 w-4" />,
-  },
-];
+import { BarChart3, Download, TrendingUp, TrendingDown } from "lucide-react";
 
 const salesData = [
   {
@@ -95,176 +58,170 @@ const topProducts = [
 
 export default function LaporanPage() {
   return (
-    <ProtectedRoute requiredRole="umkm">
-      <DashboardLayout title="Laporan Penjualan" navigation={umkmNavigation}>
-        <div className="space-y-6">
-          {/* Header */}
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-2xl font-bold">Laporan</h2>
-              <p className="text-muted-foreground">
-                Analisis penjualan dan performa UMKM
-              </p>
-            </div>
-            <div className="flex gap-2">
-              <Button variant="outline">
-                <Download className="h-4 w-4 mr-2" />
-                Export PDF
-              </Button>
-              <Button variant="outline">
-                <Download className="h-4 w-4 mr-2" />
-                Export Excel
-              </Button>
-            </div>
-          </div>
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold">Laporan</h2>
+          <p className="text-muted-foreground">
+            Analisis penjualan dan performa UMKM
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline">
+            <Download className="h-4 w-4 mr-2" />
+            Export PDF
+          </Button>
+          <Button variant="outline">
+            <Download className="h-4 w-4 mr-2" />
+            Export Excel
+          </Button>
+        </div>
+      </div>
 
-          {/* Sales Overview */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {salesData.map((data) => (
-              <Card key={data.period}>
-                <CardHeader>
-                  <CardTitle className="text-sm font-medium">
-                    {data.period}
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="text-2xl font-bold">{data.revenue}</div>
-                  <div className="flex items-center justify-between mt-2">
-                    <p className="text-sm text-muted-foreground">
-                      {data.transactions} transaksi
-                    </p>
-                    <div className="flex items-center gap-1 text-xs">
-                      <TrendingUp className="h-3 w-3 text-green-500" />
-                      <span className="text-green-500">{data.growth}</span>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-
-          {/* Charts Section */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <Card>
-              <CardHeader>
-                <CardTitle>Tren Penjualan</CardTitle>
-                <CardDescription>Penjualan 7 hari terakhir</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="h-64 flex items-center justify-center bg-muted rounded-lg">
-                  <div className="text-center">
-                    <BarChart3 className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
-                    <p className="text-muted-foreground">Grafik Penjualan</p>
-                    <p className="text-sm text-muted-foreground">
-                      Data visualisasi akan ditampilkan di sini
-                    </p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle>Kategori Produk</CardTitle>
-                <CardDescription>
-                  Distribusi penjualan per kategori
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-4">
-                  {[
-                    {
-                      category: "Minuman",
-                      percentage: 45,
-                      revenue: "Rp 26,437,500",
-                    },
-                    {
-                      category: "Makanan",
-                      percentage: 35,
-                      revenue: "Rp 20,562,500",
-                    },
-                    {
-                      category: "Paket",
-                      percentage: 20,
-                      revenue: "Rp 11,750,000",
-                    },
-                  ].map((item) => (
-                    <div key={item.category} className="space-y-2">
-                      <div className="flex justify-between">
-                        <span className="font-medium">{item.category}</span>
-                        <span className="text-sm text-muted-foreground">
-                          {item.percentage}%
-                        </span>
-                      </div>
-                      <div className="w-full bg-muted rounded-full h-2">
-                        <div
-                          className="bg-primary h-2 rounded-full"
-                          style={{ width: `${item.percentage}%` }}
-                        ></div>
-                      </div>
-                      <p className="text-sm text-muted-foreground">
-                        {item.revenue}
-                      </p>
-                    </div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-
-          {/* Top Products */}
-          <Card>
+      {/* Sales Overview */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        {salesData.map((data) => (
+          <Card key={data.period}>
             <CardHeader>
-              <CardTitle>Produk Terlaris</CardTitle>
-              <CardDescription>
-                Produk dengan penjualan tertinggi bulan ini
-              </CardDescription>
+              <CardTitle className="text-sm font-medium">
+                {data.period}
+              </CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="space-y-4">
-                {topProducts.map((product, index) => (
-                  <div
-                    key={product.name}
-                    className="flex items-center justify-between p-4 border rounded-lg"
-                  >
-                    <div className="flex items-center gap-4">
-                      <div className="w-8 h-8 bg-primary rounded-full flex items-center justify-center text-white font-bold text-sm">
-                        {index + 1}
-                      </div>
-                      <div>
-                        <h3 className="font-medium">{product.name}</h3>
-                        <p className="text-sm text-muted-foreground">
-                          {product.sold} terjual
-                        </p>
-                      </div>
-                    </div>
-
-                    <div className="flex items-center gap-4">
-                      <div className="text-right">
-                        <p className="font-medium">{product.revenue}</p>
-                        <div className="flex items-center gap-1">
-                          {product.trend === "up" ? (
-                            <TrendingUp className="h-3 w-3 text-green-500" />
-                          ) : (
-                            <TrendingDown className="h-3 w-3 text-red-500" />
-                          )}
-                          <Badge
-                            variant={
-                              product.trend === "up" ? "default" : "secondary"
-                            }
-                          >
-                            {product.trend === "up" ? "Naik" : "Turun"}
-                          </Badge>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                ))}
+              <div className="text-2xl font-bold">{data.revenue}</div>
+              <div className="flex items-center justify-between mt-2">
+                <p className="text-sm text-muted-foreground">
+                  {data.transactions} transaksi
+                </p>
+                <div className="flex items-center gap-1 text-xs">
+                  <TrendingUp className="h-3 w-3 text-green-500" />
+                  <span className="text-green-500">{data.growth}</span>
+                </div>
               </div>
             </CardContent>
           </Card>
-        </div>
-      </DashboardLayout>
-    </ProtectedRoute>
+        ))}
+      </div>
+
+      {/* Charts Section */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Tren Penjualan</CardTitle>
+            <CardDescription>Penjualan 7 hari terakhir</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="h-64 flex items-center justify-center bg-muted rounded-lg">
+              <div className="text-center">
+                <BarChart3 className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
+                <p className="text-muted-foreground">Grafik Penjualan</p>
+                <p className="text-sm text-muted-foreground">
+                  Data visualisasi akan ditampilkan di sini
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Kategori Produk</CardTitle>
+            <CardDescription>Distribusi penjualan per kategori</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              {[
+                {
+                  category: "Minuman",
+                  percentage: 45,
+                  revenue: "Rp 26,437,500",
+                },
+                {
+                  category: "Makanan",
+                  percentage: 35,
+                  revenue: "Rp 20,562,500",
+                },
+                {
+                  category: "Paket",
+                  percentage: 20,
+                  revenue: "Rp 11,750,000",
+                },
+              ].map((item) => (
+                <div key={item.category} className="space-y-2">
+                  <div className="flex justify-between">
+                    <span className="font-medium">{item.category}</span>
+                    <span className="text-sm text-muted-foreground">
+                      {item.percentage}%
+                    </span>
+                  </div>
+                  <div className="w-full bg-muted rounded-full h-2">
+                    <div
+                      className="bg-primary h-2 rounded-full"
+                      style={{ width: `${item.percentage}%` }}
+                    ></div>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    {item.revenue}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Top Products */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Produk Terlaris</CardTitle>
+          <CardDescription>
+            Produk dengan penjualan tertinggi bulan ini
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {topProducts.map((product, index) => (
+              <div
+                key={product.name}
+                className="flex items-center justify-between p-4 border rounded-lg"
+              >
+                <div className="flex items-center gap-4">
+                  <div className="w-8 h-8 bg-primary rounded-full flex items-center justify-center text-white font-bold text-sm">
+                    {index + 1}
+                  </div>
+                  <div>
+                    <h3 className="font-medium">{product.name}</h3>
+                    <p className="text-sm text-muted-foreground">
+                      {product.sold} terjual
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-4">
+                  <div className="text-right">
+                    <p className="font-medium">{product.revenue}</p>
+                    <div className="flex items-center gap-1">
+                      {product.trend === "up" ? (
+                        <TrendingUp className="h-3 w-3 text-green-500" />
+                      ) : (
+                        <TrendingDown className="h-3 w-3 text-red-500" />
+                      )}
+                      <Badge
+                        variant={
+                          product.trend === "up" ? "default" : "secondary"
+                        }
+                      >
+                        {product.trend === "up" ? "Naik" : "Turun"}
+                      </Badge>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/src/app/umkm/pengaturan/page.tsx
+++ b/src/app/umkm/pengaturan/page.tsx
@@ -1,7 +1,5 @@
 /** @format */
 
-import { ProtectedRoute } from "@/components/shared/protected-route";
-import { DashboardLayout } from "@/components/shared/dashboard-layout";
 import {
   Card,
   CardContent,
@@ -13,268 +11,219 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
-import {
-  BarChart3,
-  Package,
-  ShoppingCart,
-  Settings,
-  FileText,
-  Calculator,
-  Store,
-  Bell,
-  CreditCard,
-  Shield,
-} from "lucide-react";
-
-const umkmNavigation = [
-  {
-    name: "Dashboard",
-    href: "/dashboard",
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    name: "Inventaris",
-    href: "/inventaris",
-    icon: <Package className="h-4 w-4" />,
-  },
-  {
-    name: "Harga Bertingkat",
-    href: "/harga-bertingkat",
-    icon: <Calculator className="h-4 w-4" />,
-  },
-  { name: "POS", href: "/pos", icon: <ShoppingCart className="h-4 w-4" /> },
-  { name: "Laporan", href: "/laporan", icon: <FileText className="h-4 w-4" /> },
-  {
-    name: "Pengaturan",
-    href: "/pengaturan",
-    icon: <Settings className="h-4 w-4" />,
-  },
-];
+import { ShoppingCart, Store, Bell, CreditCard, Shield } from "lucide-react";
 
 export default function PengaturanPage() {
   return (
-    <ProtectedRoute requiredRole="umkm">
-      <DashboardLayout title="Pengaturan UMKM" navigation={umkmNavigation}>
-        <div className="space-y-6">
-          {/* Header */}
-          <div>
-            <h2 className="text-2xl font-bold">Pengaturan</h2>
-            <p className="text-muted-foreground">
-              Kelola konfigurasi dan preferensi UMKM
-            </p>
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h2 className="text-2xl font-bold">Pengaturan</h2>
+        <p className="text-muted-foreground">
+          Kelola konfigurasi dan preferensi UMKM
+        </p>
+      </div>
+
+      {/* Business Information */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Store className="h-5 w-5" />
+            <CardTitle>Informasi Usaha</CardTitle>
           </div>
+          <CardDescription>Data dasar usaha Anda</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="business-name">Nama Usaha</Label>
+              <Input id="business-name" defaultValue="Warung Makan Sederhana" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="owner-name">Nama Pemilik</Label>
+              <Input id="owner-name" defaultValue="Budi Santoso" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="phone">Nomor Telepon</Label>
+              <Input id="phone" defaultValue="+62 812-3456-7890" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                defaultValue="budi@warungmakan.com"
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="address">Alamat</Label>
+            <Input
+              id="address"
+              defaultValue="Jl. Merdeka No. 123, Jakarta Pusat"
+            />
+          </div>
+          <Button>Simpan Perubahan</Button>
+        </CardContent>
+      </Card>
 
-          {/* Business Information */}
-          <Card>
-            <CardHeader>
-              <div className="flex items-center gap-2">
-                <Store className="h-5 w-5" />
-                <CardTitle>Informasi Usaha</CardTitle>
-              </div>
-              <CardDescription>Data dasar usaha Anda</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="business-name">Nama Usaha</Label>
-                  <Input
-                    id="business-name"
-                    defaultValue="Warung Makan Sederhana"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="owner-name">Nama Pemilik</Label>
-                  <Input id="owner-name" defaultValue="Budi Santoso" />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="phone">Nomor Telepon</Label>
-                  <Input id="phone" defaultValue="+62 812-3456-7890" />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="email">Email</Label>
-                  <Input
-                    id="email"
-                    type="email"
-                    defaultValue="budi@warungmakan.com"
-                  />
-                </div>
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="address">Alamat</Label>
-                <Input
-                  id="address"
-                  defaultValue="Jl. Merdeka No. 123, Jakarta Pusat"
-                />
-              </div>
-              <Button>Simpan Perubahan</Button>
-            </CardContent>
-          </Card>
+      {/* POS Settings */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <ShoppingCart className="h-5 w-5" />
+            <CardTitle>Pengaturan POS</CardTitle>
+          </div>
+          <CardDescription>Konfigurasi sistem point of sale</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <Label htmlFor="auto-print">Cetak Struk Otomatis</Label>
+              <p className="text-sm text-muted-foreground">
+                Cetak struk setelah transaksi selesai
+              </p>
+            </div>
+            <Switch id="auto-print" defaultChecked />
+          </div>
+          <div className="flex items-center justify-between">
+            <div>
+              <Label htmlFor="tax-included">Harga Sudah Termasuk Pajak</Label>
+              <p className="text-sm text-muted-foreground">
+                Tampilkan harga final di POS
+              </p>
+            </div>
+            <Switch id="tax-included" />
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="tax-rate">Tarif Pajak (%)</Label>
+              <Input id="tax-rate" type="number" defaultValue="10" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="currency">Mata Uang</Label>
+              <Input id="currency" defaultValue="IDR" disabled />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
 
-          {/* POS Settings */}
-          <Card>
-            <CardHeader>
-              <div className="flex items-center gap-2">
-                <ShoppingCart className="h-5 w-5" />
-                <CardTitle>Pengaturan POS</CardTitle>
-              </div>
-              <CardDescription>
-                Konfigurasi sistem point of sale
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label htmlFor="auto-print">Cetak Struk Otomatis</Label>
-                  <p className="text-sm text-muted-foreground">
-                    Cetak struk setelah transaksi selesai
-                  </p>
-                </div>
-                <Switch id="auto-print" defaultChecked />
-              </div>
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label htmlFor="tax-included">
-                    Harga Sudah Termasuk Pajak
-                  </Label>
-                  <p className="text-sm text-muted-foreground">
-                    Tampilkan harga final di POS
-                  </p>
-                </div>
-                <Switch id="tax-included" />
-              </div>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="tax-rate">Tarif Pajak (%)</Label>
-                  <Input id="tax-rate" type="number" defaultValue="10" />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="currency">Mata Uang</Label>
-                  <Input id="currency" defaultValue="IDR" disabled />
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+      {/* Notification Settings */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Bell className="h-5 w-5" />
+            <CardTitle>Notifikasi</CardTitle>
+          </div>
+          <CardDescription>Atur preferensi notifikasi</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <Label htmlFor="low-stock">Peringatan Stok Rendah</Label>
+              <p className="text-sm text-muted-foreground">
+                Notifikasi ketika stok produk menipis
+              </p>
+            </div>
+            <Switch id="low-stock" defaultChecked />
+          </div>
+          <div className="flex items-center justify-between">
+            <div>
+              <Label htmlFor="daily-report">Laporan Harian</Label>
+              <p className="text-sm text-muted-foreground">
+                Kirim ringkasan penjualan harian
+              </p>
+            </div>
+            <Switch id="daily-report" defaultChecked />
+          </div>
+          <div className="flex items-center justify-between">
+            <div>
+              <Label htmlFor="payment-reminder">Pengingat Pembayaran</Label>
+              <p className="text-sm text-muted-foreground">
+                Notifikasi untuk tagihan yang belum dibayar
+              </p>
+            </div>
+            <Switch id="payment-reminder" />
+          </div>
+        </CardContent>
+      </Card>
 
-          {/* Notification Settings */}
-          <Card>
-            <CardHeader>
-              <div className="flex items-center gap-2">
-                <Bell className="h-5 w-5" />
-                <CardTitle>Notifikasi</CardTitle>
-              </div>
-              <CardDescription>Atur preferensi notifikasi</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label htmlFor="low-stock">Peringatan Stok Rendah</Label>
-                  <p className="text-sm text-muted-foreground">
-                    Notifikasi ketika stok produk menipis
-                  </p>
-                </div>
-                <Switch id="low-stock" defaultChecked />
-              </div>
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label htmlFor="daily-report">Laporan Harian</Label>
-                  <p className="text-sm text-muted-foreground">
-                    Kirim ringkasan penjualan harian
-                  </p>
-                </div>
-                <Switch id="daily-report" defaultChecked />
-              </div>
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label htmlFor="payment-reminder">Pengingat Pembayaran</Label>
-                  <p className="text-sm text-muted-foreground">
-                    Notifikasi untuk tagihan yang belum dibayar
-                  </p>
-                </div>
-                <Switch id="payment-reminder" />
-              </div>
-            </CardContent>
-          </Card>
+      {/* Payment Methods */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <CreditCard className="h-5 w-5" />
+            <CardTitle>Metode Pembayaran</CardTitle>
+          </div>
+          <CardDescription>
+            Konfigurasi opsi pembayaran yang diterima
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <Label htmlFor="cash">Tunai</Label>
+              <p className="text-sm text-muted-foreground">
+                Pembayaran dengan uang tunai
+              </p>
+            </div>
+            <Switch id="cash" defaultChecked disabled />
+          </div>
+          <div className="flex items-center justify-between">
+            <div>
+              <Label htmlFor="debit">Kartu Debit</Label>
+              <p className="text-sm text-muted-foreground">
+                Pembayaran dengan kartu debit
+              </p>
+            </div>
+            <Switch id="debit" defaultChecked />
+          </div>
+          <div className="flex items-center justify-between">
+            <div>
+              <Label htmlFor="ewallet">E-Wallet</Label>
+              <p className="text-sm text-muted-foreground">
+                GoPay, OVO, DANA, dll
+              </p>
+            </div>
+            <Switch id="ewallet" defaultChecked />
+          </div>
+          <div className="flex items-center justify-between">
+            <div>
+              <Label htmlFor="qris">QRIS</Label>
+              <p className="text-sm text-muted-foreground">
+                Pembayaran dengan QR Code
+              </p>
+            </div>
+            <Switch id="qris" defaultChecked />
+          </div>
+        </CardContent>
+      </Card>
 
-          {/* Payment Methods */}
-          <Card>
-            <CardHeader>
-              <div className="flex items-center gap-2">
-                <CreditCard className="h-5 w-5" />
-                <CardTitle>Metode Pembayaran</CardTitle>
-              </div>
-              <CardDescription>
-                Konfigurasi opsi pembayaran yang diterima
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label htmlFor="cash">Tunai</Label>
-                  <p className="text-sm text-muted-foreground">
-                    Pembayaran dengan uang tunai
-                  </p>
-                </div>
-                <Switch id="cash" defaultChecked disabled />
-              </div>
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label htmlFor="debit">Kartu Debit</Label>
-                  <p className="text-sm text-muted-foreground">
-                    Pembayaran dengan kartu debit
-                  </p>
-                </div>
-                <Switch id="debit" defaultChecked />
-              </div>
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label htmlFor="ewallet">E-Wallet</Label>
-                  <p className="text-sm text-muted-foreground">
-                    GoPay, OVO, DANA, dll
-                  </p>
-                </div>
-                <Switch id="ewallet" defaultChecked />
-              </div>
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label htmlFor="qris">QRIS</Label>
-                  <p className="text-sm text-muted-foreground">
-                    Pembayaran dengan QR Code
-                  </p>
-                </div>
-                <Switch id="qris" defaultChecked />
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Security Settings */}
-          <Card>
-            <CardHeader>
-              <div className="flex items-center gap-2">
-                <Shield className="h-5 w-5" />
-                <CardTitle>Keamanan</CardTitle>
-              </div>
-              <CardDescription>Pengaturan keamanan akun</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="current-password">Password Saat Ini</Label>
-                <Input id="current-password" type="password" />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="new-password">Password Baru</Label>
-                <Input id="new-password" type="password" />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="confirm-password">
-                  Konfirmasi Password Baru
-                </Label>
-                <Input id="confirm-password" type="password" />
-              </div>
-              <Button>Ubah Password</Button>
-            </CardContent>
-          </Card>
-        </div>
-      </DashboardLayout>
-    </ProtectedRoute>
+      {/* Security Settings */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Shield className="h-5 w-5" />
+            <CardTitle>Keamanan</CardTitle>
+          </div>
+          <CardDescription>Pengaturan keamanan akun</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="current-password">Password Saat Ini</Label>
+            <Input id="current-password" type="password" />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="new-password">Password Baru</Label>
+            <Input id="new-password" type="password" />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="confirm-password">Konfirmasi Password Baru</Label>
+            <Input id="confirm-password" type="password" />
+          </div>
+          <Button>Ubah Password</Button>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/src/app/umkm/pos/page.tsx
+++ b/src/app/umkm/pos/page.tsx
@@ -1,7 +1,5 @@
 /** @format */
 
-import { ProtectedRoute } from "@/components/shared/protected-route";
-import { DashboardLayout } from "@/components/shared/dashboard-layout";
 import {
   Card,
   CardContent,
@@ -13,12 +11,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import {
-  BarChart3,
-  Package,
   ShoppingCart,
-  Settings,
-  FileText,
-  Calculator,
   Search,
   Plus,
   Minus,
@@ -26,31 +19,6 @@ import {
   CreditCard,
   Banknote,
 } from "lucide-react";
-
-const umkmNavigation = [
-  {
-    name: "Dashboard",
-    href: "/dashboard",
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    name: "Inventaris",
-    href: "/inventaris",
-    icon: <Package className="h-4 w-4" />,
-  },
-  {
-    name: "Harga Bertingkat",
-    href: "/harga-bertingkat",
-    icon: <Calculator className="h-4 w-4" />,
-  },
-  { name: "POS", href: "/pos", icon: <ShoppingCart className="h-4 w-4" /> },
-  { name: "Laporan", href: "/laporan", icon: <FileText className="h-4 w-4" /> },
-  {
-    name: "Pengaturan",
-    href: "/pengaturan",
-    icon: <Settings className="h-4 w-4" />,
-  },
-];
 
 const products = [
   { id: "P001", name: "Kopi Arabica Premium", price: 15000, stock: 25 },
@@ -68,157 +36,151 @@ const cartItems = [
 export default function POSPage() {
   const subtotal = cartItems.reduce(
     (sum, item) => sum + item.price * item.quantity,
-    0
+    0,
   );
   const tax = subtotal * 0.1; // 10% tax
   const total = subtotal + tax;
 
   return (
-    <ProtectedRoute requiredRole="umkm">
-      <DashboardLayout title="Point of Sale (POS)" navigation={umkmNavigation}>
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {/* Product Selection */}
-          <div className="lg:col-span-2 space-y-6">
-            <Card>
-              <CardHeader>
-                <CardTitle>Pilih Produk</CardTitle>
-                <CardDescription>
-                  Klik produk untuk menambahkan ke keranjang
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="mb-4">
-                  <div className="relative">
-                    <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                    <Input placeholder="Cari produk..." className="pl-10" />
+    <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      {/* Product Selection */}
+      <div className="lg:col-span-2 space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Pilih Produk</CardTitle>
+            <CardDescription>
+              Klik produk untuk menambahkan ke keranjang
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="mb-4">
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <Input placeholder="Cari produk..." className="pl-10" />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {products.map((product) => (
+                <div
+                  key={product.id}
+                  className="p-4 border rounded-lg hover:bg-muted cursor-pointer transition-colors"
+                >
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <h3 className="font-medium">{product.name}</h3>
+                      <p className="text-sm text-muted-foreground">
+                        Stok: {product.stock}
+                      </p>
+                    </div>
+                    <div className="text-right">
+                      <p className="font-bold">
+                        Rp {product.price.toLocaleString()}
+                      </p>
+                      <Badge
+                        variant={product.stock > 10 ? "default" : "secondary"}
+                      >
+                        {product.stock > 10 ? "Tersedia" : "Terbatas"}
+                      </Badge>
+                    </div>
                   </div>
                 </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
 
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  {products.map((product) => (
-                    <div
-                      key={product.id}
-                      className="p-4 border rounded-lg hover:bg-muted cursor-pointer transition-colors"
-                    >
-                      <div className="flex items-center justify-between">
-                        <div>
-                          <h3 className="font-medium">{product.name}</h3>
-                          <p className="text-sm text-muted-foreground">
-                            Stok: {product.stock}
-                          </p>
-                        </div>
-                        <div className="text-right">
-                          <p className="font-bold">
-                            Rp {product.price.toLocaleString()}
-                          </p>
-                          <Badge
-                            variant={
-                              product.stock > 10 ? "default" : "secondary"
-                            }
-                          >
-                            {product.stock > 10 ? "Tersedia" : "Terbatas"}
-                          </Badge>
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-
-          {/* Cart and Checkout */}
-          <div className="space-y-6">
-            <Card>
-              <CardHeader>
-                <CardTitle>Keranjang Belanja</CardTitle>
-                <CardDescription>Item yang dipilih</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-4">
-                  {cartItems.map((item) => (
-                    <div
-                      key={item.id}
-                      className="flex items-center justify-between p-3 border rounded-lg"
-                    >
-                      <div className="flex-1">
-                        <h4 className="font-medium text-sm">{item.name}</h4>
-                        <p className="text-sm text-muted-foreground">
-                          Rp {item.price.toLocaleString()}
-                        </p>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <Button variant="ghost" size="icon" className="h-8 w-8">
-                          <Minus className="h-4 w-4" />
-                        </Button>
-                        <span className="w-8 text-center">{item.quantity}</span>
-                        <Button variant="ghost" size="icon" className="h-8 w-8">
-                          <Plus className="h-4 w-4" />
-                        </Button>
-                        <Button variant="ghost" size="icon" className="h-8 w-8">
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    </div>
-                  ))}
-
-                  {cartItems.length === 0 && (
-                    <div className="text-center py-8 text-muted-foreground">
-                      <ShoppingCart className="h-12 w-12 mx-auto mb-4 opacity-50" />
-                      <p>Keranjang kosong</p>
-                    </div>
-                  )}
-                </div>
-              </CardContent>
-            </Card>
-
-            {cartItems.length > 0 && (
-              <Card>
-                <CardHeader>
-                  <CardTitle>Ringkasan Pembayaran</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div className="space-y-2">
-                    <div className="flex justify-between">
-                      <span>Subtotal</span>
-                      <span>Rp {subtotal.toLocaleString()}</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span>Pajak (10%)</span>
-                      <span>Rp {tax.toLocaleString()}</span>
-                    </div>
-                    <div className="border-t pt-2">
-                      <div className="flex justify-between font-bold">
-                        <span>Total</span>
-                        <span>Rp {total.toLocaleString()}</span>
-                      </div>
-                    </div>
+      {/* Cart and Checkout */}
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Keranjang Belanja</CardTitle>
+            <CardDescription>Item yang dipilih</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              {cartItems.map((item) => (
+                <div
+                  key={item.id}
+                  className="flex items-center justify-between p-3 border rounded-lg"
+                >
+                  <div className="flex-1">
+                    <h4 className="font-medium text-sm">{item.name}</h4>
+                    <p className="text-sm text-muted-foreground">
+                      Rp {item.price.toLocaleString()}
+                    </p>
                   </div>
-
-                  <div className="space-y-2">
-                    <Button className="w-full" size="lg">
-                      <Banknote className="h-4 w-4 mr-2" />
-                      Bayar Tunai
+                  <div className="flex items-center gap-2">
+                    <Button variant="ghost" size="icon" className="h-8 w-8">
+                      <Minus className="h-4 w-4" />
                     </Button>
-                    <Button
-                      variant="outline"
-                      className="w-full bg-transparent"
-                      size="lg"
-                    >
-                      <CreditCard className="h-4 w-4 mr-2" />
-                      Bayar Non-Tunai
+                    <span className="w-8 text-center">{item.quantity}</span>
+                    <Button variant="ghost" size="icon" className="h-8 w-8">
+                      <Plus className="h-4 w-4" />
+                    </Button>
+                    <Button variant="ghost" size="icon" className="h-8 w-8">
+                      <Trash2 className="h-4 w-4" />
                     </Button>
                   </div>
+                </div>
+              ))}
 
-                  <Button variant="ghost" className="w-full">
-                    Simpan sebagai Draft
-                  </Button>
-                </CardContent>
-              </Card>
-            )}
-          </div>
-        </div>
-      </DashboardLayout>
-    </ProtectedRoute>
+              {cartItems.length === 0 && (
+                <div className="text-center py-8 text-muted-foreground">
+                  <ShoppingCart className="h-12 w-12 mx-auto mb-4 opacity-50" />
+                  <p>Keranjang kosong</p>
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {cartItems.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Ringkasan Pembayaran</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <div className="flex justify-between">
+                  <span>Subtotal</span>
+                  <span>Rp {subtotal.toLocaleString()}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Pajak (10%)</span>
+                  <span>Rp {tax.toLocaleString()}</span>
+                </div>
+                <div className="border-t pt-2">
+                  <div className="flex justify-between font-bold">
+                    <span>Total</span>
+                    <span>Rp {total.toLocaleString()}</span>
+                  </div>
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Button className="w-full" size="lg">
+                  <Banknote className="h-4 w-4 mr-2" />
+                  Bayar Tunai
+                </Button>
+                <Button
+                  variant="outline"
+                  className="w-full bg-transparent"
+                  size="lg"
+                >
+                  <CreditCard className="h-4 w-4 mr-2" />
+                  Bayar Non-Tunai
+                </Button>
+              </div>
+
+              <Button variant="ghost" className="w-full">
+                Simpan sebagai Draft
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
   );
 }

--- a/src/app/vendor/clients/page.tsx
+++ b/src/app/vendor/clients/page.tsx
@@ -4,46 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import {
-  BarChart3,
-  Users,
-  Package,
-  FileText,
-  Bell,
-  Ticket,
-  Plus,
-  Search,
-  Mail,
-  Phone,
-} from "lucide-react";
-import { DashboardLayout } from "@/components/shared/dashboard-layout";
-import { ProtectedRoute } from "@/components/shared/protected-route";
-
-const vendorNavigation = [
-  {
-    name: "Dashboard",
-    href: "/dashboard",
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    name: "Products",
-    href: "/products",
-    icon: <Package className="h-4 w-4" />,
-  },
-  { name: "Clients", href: "/clients", icon: <Users className="h-4 w-4" /> },
-  {
-    name: "Invoices",
-    href: "/invoices",
-    icon: <FileText className="h-4 w-4" />,
-  },
-  { name: "Users", href: "/users", icon: <Users className="h-4 w-4" /> },
-  {
-    name: "Notifications",
-    href: "/notifications",
-    icon: <Bell className="h-4 w-4" />,
-  },
-  { name: "Tickets", href: "/tickets", icon: <Ticket className="h-4 w-4" /> },
-];
+import { Plus, Search, Mail, Phone } from "lucide-react";
 
 const clients = [
   {
@@ -77,85 +38,75 @@ const clients = [
 
 export default function ClientsPage() {
   return (
-    <ProtectedRoute requiredRole="vendor">
-      <DashboardLayout title="Clients Management" navigation={vendorNavigation}>
-        <div className="space-y-6">
-          {/* Header */}
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-2xl font-bold">Clients</h2>
-              <p className="text-muted-foreground">
-                Manage your client relationships
-              </p>
-            </div>
-            <Button>
-              <Plus className="h-4 w-4 mr-2" />
-              Add Client
-            </Button>
-          </div>
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold">Clients</h2>
+          <p className="text-muted-foreground">
+            Manage your client relationships
+          </p>
+        </div>
+        <Button>
+          <Plus className="h-4 w-4 mr-2" />
+          Add Client
+        </Button>
+      </div>
 
-          {/* Search */}
-          <Card>
-            <CardContent className="pt-6">
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                <Input placeholder="Search clients..." className="pl-10" />
+      {/* Search */}
+      <Card>
+        <CardContent className="pt-6">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input placeholder="Search clients..." className="pl-10" />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Clients Grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {clients.map((client) => (
+          <Card key={client.id}>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <CardTitle className="text-lg">{client.name}</CardTitle>
+                <Badge
+                  variant={client.status === "active" ? "default" : "secondary"}
+                >
+                  {client.status}
+                </Badge>
               </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <div className="flex items-center gap-2 text-sm">
+                  <Mail className="h-4 w-4 text-muted-foreground" />
+                  <span>{client.email}</span>
+                </div>
+                <div className="flex items-center gap-2 text-sm">
+                  <Phone className="h-4 w-4 text-muted-foreground" />
+                  <span>{client.phone}</span>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-4 pt-4 border-t">
+                <div>
+                  <p className="text-sm text-muted-foreground">Total Orders</p>
+                  <p className="font-semibold">{client.totalOrders}</p>
+                </div>
+                <div>
+                  <p className="text-sm text-muted-foreground">Total Spent</p>
+                  <p className="font-semibold">{client.totalSpent}</p>
+                </div>
+              </div>
+
+              <Button variant="outline" className="w-full bg-transparent">
+                View Details
+              </Button>
             </CardContent>
           </Card>
-
-          {/* Clients Grid */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {clients.map((client) => (
-              <Card key={client.id}>
-                <CardHeader>
-                  <div className="flex items-center justify-between">
-                    <CardTitle className="text-lg">{client.name}</CardTitle>
-                    <Badge
-                      variant={
-                        client.status === "active" ? "default" : "secondary"
-                      }
-                    >
-                      {client.status}
-                    </Badge>
-                  </div>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div className="space-y-2">
-                    <div className="flex items-center gap-2 text-sm">
-                      <Mail className="h-4 w-4 text-muted-foreground" />
-                      <span>{client.email}</span>
-                    </div>
-                    <div className="flex items-center gap-2 text-sm">
-                      <Phone className="h-4 w-4 text-muted-foreground" />
-                      <span>{client.phone}</span>
-                    </div>
-                  </div>
-
-                  <div className="grid grid-cols-2 gap-4 pt-4 border-t">
-                    <div>
-                      <p className="text-sm text-muted-foreground">
-                        Total Orders
-                      </p>
-                      <p className="font-semibold">{client.totalOrders}</p>
-                    </div>
-                    <div>
-                      <p className="text-sm text-muted-foreground">
-                        Total Spent
-                      </p>
-                      <p className="font-semibold">{client.totalSpent}</p>
-                    </div>
-                  </div>
-
-                  <Button variant="outline" className="w-full bg-transparent">
-                    View Details
-                  </Button>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </div>
-      </DashboardLayout>
-    </ProtectedRoute>
+        ))}
+      </div>
+    </div>
   );
 }

--- a/src/app/vendor/dashboard/page.tsx
+++ b/src/app/vendor/dashboard/page.tsx
@@ -9,43 +9,13 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import {
-  BarChart3,
   Users,
   Package,
   FileText,
-  Bell,
   Ticket,
   TrendingUp,
   DollarSign,
 } from "lucide-react";
-import { DashboardLayout } from "@/components/shared/dashboard-layout";
-import { ProtectedRoute } from "@/components/shared/protected-route";
-
-const vendorNavigation = [
-  {
-    name: "Dashboard",
-    href: "/dashboard",
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    name: "Products",
-    href: "/products",
-    icon: <Package className="h-4 w-4" />,
-  },
-  { name: "Clients", href: "/clients", icon: <Users className="h-4 w-4" /> },
-  {
-    name: "Invoices",
-    href: "/invoices",
-    icon: <FileText className="h-4 w-4" />,
-  },
-  { name: "Users", href: "/users", icon: <Users className="h-4 w-4" /> },
-  {
-    name: "Notifications",
-    href: "/notifications",
-    icon: <Bell className="h-4 w-4" />,
-  },
-  { name: "Tickets", href: "/tickets", icon: <Ticket className="h-4 w-4" /> },
-];
 
 const dashboardStats = [
   {
@@ -80,155 +50,144 @@ const dashboardStats = [
 
 export default function VendorDashboard() {
   return (
-    <ProtectedRoute requiredRole="vendor">
-      <DashboardLayout title="Vendor Dashboard" navigation={vendorNavigation}>
-        <div className="space-y-6">
-          {/* Stats Cards */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {dashboardStats.map((stat) => (
-              <Card key={stat.title}>
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                  <CardTitle className="text-sm font-medium">
-                    {stat.title}
-                  </CardTitle>
-                  {stat.icon}
-                </CardHeader>
-                <CardContent>
-                  <div className="text-2xl font-bold">{stat.value}</div>
-                  <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                    <TrendingUp
-                      className={`h-3 w-3 ${
-                        stat.trend === "up" ? "text-green-500" : "text-red-500"
-                      }`}
-                    />
-                    <span
-                      className={
-                        stat.trend === "up" ? "text-green-500" : "text-red-500"
+    <div className="space-y-6">
+      {/* Stats Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        {dashboardStats.map((stat) => (
+          <Card key={stat.title}>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">
+                {stat.title}
+              </CardTitle>
+              {stat.icon}
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{stat.value}</div>
+              <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                <TrendingUp
+                  className={`h-3 w-3 ${
+                    stat.trend === "up" ? "text-green-500" : "text-red-500"
+                  }`}
+                />
+                <span
+                  className={
+                    stat.trend === "up" ? "text-green-500" : "text-red-500"
+                  }
+                >
+                  {stat.change}
+                </span>
+                <span>from last month</span>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Recent Activity */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Recent Orders</CardTitle>
+            <CardDescription>Latest orders from your clients</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              {[
+                {
+                  client: "PT Maju Jaya",
+                  product: "Office Supplies",
+                  amount: "Rp 450,000",
+                  status: "completed",
+                },
+                {
+                  client: "CV Berkah",
+                  product: "Cleaning Equipment",
+                  amount: "Rp 320,000",
+                  status: "pending",
+                },
+                {
+                  client: "UD Sejahtera",
+                  product: "Stationery",
+                  amount: "Rp 180,000",
+                  status: "processing",
+                },
+              ].map((order, index) => (
+                <div key={index} className="flex items-center justify-between">
+                  <div>
+                    <p className="font-medium">{order.client}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {order.product}
+                    </p>
+                  </div>
+                  <div className="text-right">
+                    <p className="font-medium">{order.amount}</p>
+                    <Badge
+                      variant={
+                        order.status === "completed"
+                          ? "default"
+                          : order.status === "pending"
+                            ? "secondary"
+                            : "outline"
                       }
                     >
-                      {stat.change}
-                    </span>
-                    <span>from last month</span>
+                      {order.status}
+                    </Badge>
                   </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-
-          {/* Recent Activity */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <Card>
-              <CardHeader>
-                <CardTitle>Recent Orders</CardTitle>
-                <CardDescription>
-                  Latest orders from your clients
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-4">
-                  {[
-                    {
-                      client: "PT Maju Jaya",
-                      product: "Office Supplies",
-                      amount: "Rp 450,000",
-                      status: "completed",
-                    },
-                    {
-                      client: "CV Berkah",
-                      product: "Cleaning Equipment",
-                      amount: "Rp 320,000",
-                      status: "pending",
-                    },
-                    {
-                      client: "UD Sejahtera",
-                      product: "Stationery",
-                      amount: "Rp 180,000",
-                      status: "processing",
-                    },
-                  ].map((order, index) => (
-                    <div
-                      key={index}
-                      className="flex items-center justify-between"
-                    >
-                      <div>
-                        <p className="font-medium">{order.client}</p>
-                        <p className="text-sm text-muted-foreground">
-                          {order.product}
-                        </p>
-                      </div>
-                      <div className="text-right">
-                        <p className="font-medium">{order.amount}</p>
-                        <Badge
-                          variant={
-                            order.status === "completed"
-                              ? "default"
-                              : order.status === "pending"
-                              ? "secondary"
-                              : "outline"
-                          }
-                        >
-                          {order.status}
-                        </Badge>
-                      </div>
-                    </div>
-                  ))}
                 </div>
-              </CardContent>
-            </Card>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
 
-            <Card>
-              <CardHeader>
-                <CardTitle>Quick Actions</CardTitle>
-                <CardDescription>Common tasks and shortcuts</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="grid grid-cols-2 gap-4">
-                  <a
-                    href="/products"
-                    className="p-4 border rounded-lg hover:bg-muted transition-colors"
-                  >
-                    <Package className="h-6 w-6 mb-2" />
-                    <p className="font-medium">Add Product</p>
-                    <p className="text-sm text-muted-foreground">
-                      Create new product
-                    </p>
-                  </a>
-                  <a
-                    href="/invoices"
-                    className="p-4 border rounded-lg hover:bg-muted transition-colors"
-                  >
-                    <FileText className="h-6 w-6 mb-2" />
-                    <p className="font-medium">New Invoice</p>
-                    <p className="text-sm text-muted-foreground">
-                      Generate invoice
-                    </p>
-                  </a>
-                  <a
-                    href="/clients"
-                    className="p-4 border rounded-lg hover:bg-muted transition-colors"
-                  >
-                    <Users className="h-6 w-6 mb-2" />
-                    <p className="font-medium">Add Client</p>
-                    <p className="text-sm text-muted-foreground">
-                      Register new client
-                    </p>
-                  </a>
-                  <a
-                    href="/tickets"
-                    className="p-4 border rounded-lg hover:bg-muted transition-colors"
-                  >
-                    <Ticket className="h-6 w-6 mb-2" />
-                    <p className="font-medium">Support</p>
-                    <p className="text-sm text-muted-foreground">
-                      Create ticket
-                    </p>
-                  </a>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-        </div>
-      </DashboardLayout>
-    </ProtectedRoute>
+        <Card>
+          <CardHeader>
+            <CardTitle>Quick Actions</CardTitle>
+            <CardDescription>Common tasks and shortcuts</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-2 gap-4">
+              <a
+                href="/products"
+                className="p-4 border rounded-lg hover:bg-muted transition-colors"
+              >
+                <Package className="h-6 w-6 mb-2" />
+                <p className="font-medium">Add Product</p>
+                <p className="text-sm text-muted-foreground">
+                  Create new product
+                </p>
+              </a>
+              <a
+                href="/invoices"
+                className="p-4 border rounded-lg hover:bg-muted transition-colors"
+              >
+                <FileText className="h-6 w-6 mb-2" />
+                <p className="font-medium">New Invoice</p>
+                <p className="text-sm text-muted-foreground">
+                  Generate invoice
+                </p>
+              </a>
+              <a
+                href="/clients"
+                className="p-4 border rounded-lg hover:bg-muted transition-colors"
+              >
+                <Users className="h-6 w-6 mb-2" />
+                <p className="font-medium">Add Client</p>
+                <p className="text-sm text-muted-foreground">
+                  Register new client
+                </p>
+              </a>
+              <a
+                href="/tickets"
+                className="p-4 border rounded-lg hover:bg-muted transition-colors"
+              >
+                <Ticket className="h-6 w-6 mb-2" />
+                <p className="font-medium">Support</p>
+                <p className="text-sm text-muted-foreground">Create ticket</p>
+              </a>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
   );
 }

--- a/src/app/vendor/invoices/page.tsx
+++ b/src/app/vendor/invoices/page.tsx
@@ -10,46 +10,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import {
-  BarChart3,
-  Users,
-  Package,
-  FileText,
-  Bell,
-  Ticket,
-  Plus,
-  Search,
-  Download,
-  Eye,
-} from "lucide-react";
-import { DashboardLayout } from "@/components/shared/dashboard-layout";
-import { ProtectedRoute } from "@/components/shared/protected-route";
-
-const vendorNavigation = [
-  {
-    name: "Dashboard",
-    href: "/dashboard",
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    name: "Products",
-    href: "/products",
-    icon: <Package className="h-4 w-4" />,
-  },
-  { name: "Clients", href: "/clients", icon: <Users className="h-4 w-4" /> },
-  {
-    name: "Invoices",
-    href: "/invoices",
-    icon: <FileText className="h-4 w-4" />,
-  },
-  { name: "Users", href: "/users", icon: <Users className="h-4 w-4" /> },
-  {
-    name: "Notifications",
-    href: "/notifications",
-    icon: <Bell className="h-4 w-4" />,
-  },
-  { name: "Tickets", href: "/tickets", icon: <Ticket className="h-4 w-4" /> },
-];
+import { FileText, Plus, Search, Download, Eye } from "lucide-react";
 
 const invoices = [
   {
@@ -80,99 +41,90 @@ const invoices = [
 
 export default function InvoicesPage() {
   return (
-    <ProtectedRoute requiredRole="vendor">
-      <DashboardLayout
-        title="Invoices Management"
-        navigation={vendorNavigation}
-      >
-        <div className="space-y-6">
-          {/* Header */}
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-2xl font-bold">Invoices</h2>
-              <p className="text-muted-foreground">
-                Track and manage your invoices
-              </p>
-            </div>
-            <Button>
-              <Plus className="h-4 w-4 mr-2" />
-              Create Invoice
-            </Button>
-          </div>
-
-          {/* Search */}
-          <Card>
-            <CardContent className="pt-6">
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                <Input placeholder="Search invoices..." className="pl-10" />
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Invoices Table */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Invoice List</CardTitle>
-              <CardDescription>
-                All your invoices and their status
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                {invoices.map((invoice) => (
-                  <div
-                    key={invoice.id}
-                    className="flex items-center justify-between p-4 border rounded-lg"
-                  >
-                    <div className="flex items-center gap-4">
-                      <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
-                        <FileText className="h-6 w-6" />
-                      </div>
-                      <div>
-                        <h3 className="font-medium">{invoice.id}</h3>
-                        <p className="text-sm text-muted-foreground">
-                          {invoice.client}
-                        </p>
-                      </div>
-                    </div>
-
-                    <div className="flex items-center gap-6">
-                      <div className="text-right">
-                        <p className="font-medium">{invoice.amount}</p>
-                        <p className="text-sm text-muted-foreground">
-                          Due: {invoice.dueDate}
-                        </p>
-                      </div>
-
-                      <Badge
-                        variant={
-                          invoice.status === "paid"
-                            ? "default"
-                            : invoice.status === "pending"
-                            ? "secondary"
-                            : "destructive"
-                        }
-                      >
-                        {invoice.status}
-                      </Badge>
-
-                      <div className="flex items-center gap-2">
-                        <Button variant="ghost" size="icon">
-                          <Eye className="h-4 w-4" />
-                        </Button>
-                        <Button variant="ghost" size="icon">
-                          <Download className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold">Invoices</h2>
+          <p className="text-muted-foreground">
+            Track and manage your invoices
+          </p>
         </div>
-      </DashboardLayout>
-    </ProtectedRoute>
+        <Button>
+          <Plus className="h-4 w-4 mr-2" />
+          Create Invoice
+        </Button>
+      </div>
+
+      {/* Search */}
+      <Card>
+        <CardContent className="pt-6">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input placeholder="Search invoices..." className="pl-10" />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Invoices Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Invoice List</CardTitle>
+          <CardDescription>All your invoices and their status</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {invoices.map((invoice) => (
+              <div
+                key={invoice.id}
+                className="flex items-center justify-between p-4 border rounded-lg"
+              >
+                <div className="flex items-center gap-4">
+                  <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
+                    <FileText className="h-6 w-6" />
+                  </div>
+                  <div>
+                    <h3 className="font-medium">{invoice.id}</h3>
+                    <p className="text-sm text-muted-foreground">
+                      {invoice.client}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-6">
+                  <div className="text-right">
+                    <p className="font-medium">{invoice.amount}</p>
+                    <p className="text-sm text-muted-foreground">
+                      Due: {invoice.dueDate}
+                    </p>
+                  </div>
+
+                  <Badge
+                    variant={
+                      invoice.status === "paid"
+                        ? "default"
+                        : invoice.status === "pending"
+                          ? "secondary"
+                          : "destructive"
+                    }
+                  >
+                    {invoice.status}
+                  </Badge>
+
+                  <div className="flex items-center gap-2">
+                    <Button variant="ghost" size="icon">
+                      <Eye className="h-4 w-4" />
+                    </Button>
+                    <Button variant="ghost" size="icon">
+                      <Download className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/src/app/vendor/notifications/page.tsx
+++ b/src/app/vendor/notifications/page.tsx
@@ -3,45 +3,7 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import {
-  BarChart3,
-  Users,
-  Package,
-  FileText,
-  Bell,
-  Ticket,
-  CheckCircle,
-  AlertCircle,
-  Info,
-} from "lucide-react";
-import { DashboardLayout } from "@/components/shared/dashboard-layout";
-import { ProtectedRoute } from "@/components/shared/protected-route";
-
-const vendorNavigation = [
-  {
-    name: "Dashboard",
-    href: "/dashboard",
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    name: "Products",
-    href: "/products",
-    icon: <Package className="h-4 w-4" />,
-  },
-  { name: "Clients", href: "/clients", icon: <Users className="h-4 w-4" /> },
-  {
-    name: "Invoices",
-    href: "/invoices",
-    icon: <FileText className="h-4 w-4" />,
-  },
-  { name: "Users", href: "/users", icon: <Users className="h-4 w-4" /> },
-  {
-    name: "Notifications",
-    href: "/notifications",
-    icon: <Bell className="h-4 w-4" />,
-  },
-  { name: "Tickets", href: "/tickets", icon: <Ticket className="h-4 w-4" /> },
-];
+import { CheckCircle, AlertCircle, Info } from "lucide-react";
 
 const notifications = [
   {
@@ -80,72 +42,68 @@ const notifications = [
 
 export default function NotificationsPage() {
   return (
-    <ProtectedRoute requiredRole="vendor">
-      <DashboardLayout title="Notifications" navigation={vendorNavigation}>
-        <div className="space-y-6">
-          {/* Header */}
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-2xl font-bold">Notifications</h2>
-              <p className="text-muted-foreground">
-                Stay updated with your business activities
-              </p>
-            </div>
-            <Button variant="outline">Mark All as Read</Button>
-          </div>
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold">Notifications</h2>
+          <p className="text-muted-foreground">
+            Stay updated with your business activities
+          </p>
+        </div>
+        <Button variant="outline">Mark All as Read</Button>
+      </div>
 
-          {/* Notifications List */}
-          <div className="space-y-4">
-            {notifications.map((notification) => (
-              <Card
-                key={notification.id}
-                className={`${!notification.read ? "border-primary/50" : ""}`}
-              >
-                <CardContent className="pt-6">
-                  <div className="flex items-start gap-4">
-                    <div className="flex-shrink-0">
-                      {notification.type === "success" && (
-                        <div className="w-10 h-10 bg-green-100 rounded-full flex items-center justify-center">
-                          <CheckCircle className="h-5 w-5 text-green-600" />
-                        </div>
-                      )}
-                      {notification.type === "warning" && (
-                        <div className="w-10 h-10 bg-yellow-100 rounded-full flex items-center justify-center">
-                          <AlertCircle className="h-5 w-5 text-yellow-600" />
-                        </div>
-                      )}
-                      {notification.type === "info" && (
-                        <div className="w-10 h-10 bg-blue-100 rounded-full flex items-center justify-center">
-                          <Info className="h-5 w-5 text-blue-600" />
-                        </div>
-                      )}
+      {/* Notifications List */}
+      <div className="space-y-4">
+        {notifications.map((notification) => (
+          <Card
+            key={notification.id}
+            className={`${!notification.read ? "border-primary/50" : ""}`}
+          >
+            <CardContent className="pt-6">
+              <div className="flex items-start gap-4">
+                <div className="flex-shrink-0">
+                  {notification.type === "success" && (
+                    <div className="w-10 h-10 bg-green-100 rounded-full flex items-center justify-center">
+                      <CheckCircle className="h-5 w-5 text-green-600" />
                     </div>
+                  )}
+                  {notification.type === "warning" && (
+                    <div className="w-10 h-10 bg-yellow-100 rounded-full flex items-center justify-center">
+                      <AlertCircle className="h-5 w-5 text-yellow-600" />
+                    </div>
+                  )}
+                  {notification.type === "info" && (
+                    <div className="w-10 h-10 bg-blue-100 rounded-full flex items-center justify-center">
+                      <Info className="h-5 w-5 text-blue-600" />
+                    </div>
+                  )}
+                </div>
 
-                    <div className="flex-1">
-                      <div className="flex items-center justify-between">
-                        <h3 className="font-medium">{notification.title}</h3>
-                        <div className="flex items-center gap-2">
-                          {!notification.read && (
-                            <Badge variant="default" className="text-xs">
-                              New
-                            </Badge>
-                          )}
-                          <span className="text-sm text-muted-foreground">
-                            {notification.time}
-                          </span>
-                        </div>
-                      </div>
-                      <p className="text-sm text-muted-foreground mt-1">
-                        {notification.message}
-                      </p>
+                <div className="flex-1">
+                  <div className="flex items-center justify-between">
+                    <h3 className="font-medium">{notification.title}</h3>
+                    <div className="flex items-center gap-2">
+                      {!notification.read && (
+                        <Badge variant="default" className="text-xs">
+                          New
+                        </Badge>
+                      )}
+                      <span className="text-sm text-muted-foreground">
+                        {notification.time}
+                      </span>
                     </div>
                   </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </div>
-      </DashboardLayout>
-    </ProtectedRoute>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    {notification.message}
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
   );
 }

--- a/src/app/vendor/products/page.tsx
+++ b/src/app/vendor/products/page.tsx
@@ -10,46 +10,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import {
-  BarChart3,
-  Users,
-  Package,
-  FileText,
-  Bell,
-  Ticket,
-  Plus,
-  Search,
-  Edit,
-  Trash2,
-} from "lucide-react";
-import { DashboardLayout } from "@/components/shared/dashboard-layout";
-import { ProtectedRoute } from "@/components/shared/protected-route";
-
-const vendorNavigation = [
-  {
-    name: "Dashboard",
-    href: "/dashboard",
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    name: "Products",
-    href: "/products",
-    icon: <Package className="h-4 w-4" />,
-  },
-  { name: "Clients", href: "/clients", icon: <Users className="h-4 w-4" /> },
-  {
-    name: "Invoices",
-    href: "/invoices",
-    icon: <FileText className="h-4 w-4" />,
-  },
-  { name: "Users", href: "/users", icon: <Users className="h-4 w-4" /> },
-  {
-    name: "Notifications",
-    href: "/notifications",
-    icon: <Bell className="h-4 w-4" />,
-  },
-  { name: "Tickets", href: "/tickets", icon: <Ticket className="h-4 w-4" /> },
-];
+import { Package, Plus, Search, Edit, Trash2 } from "lucide-react";
 
 const products = [
   {
@@ -88,100 +49,87 @@ const products = [
 
 export default function ProductsPage() {
   return (
-    <ProtectedRoute requiredRole="vendor">
-      <DashboardLayout
-        title="Products Management"
-        navigation={vendorNavigation}
-      >
-        <div className="space-y-6">
-          {/* Header */}
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-2xl font-bold">Products</h2>
-              <p className="text-muted-foreground">
-                Manage your product catalog
-              </p>
-            </div>
-            <Button>
-              <Plus className="h-4 w-4 mr-2" />
-              Add Product
-            </Button>
-          </div>
-
-          {/* Search and Filters */}
-          <Card>
-            <CardContent className="pt-6">
-              <div className="flex items-center gap-4">
-                <div className="relative flex-1">
-                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                  <Input placeholder="Search products..." className="pl-10" />
-                </div>
-                <Button variant="outline">Filter</Button>
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Products Table */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Product List</CardTitle>
-              <CardDescription>All your products in one place</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                {products.map((product) => (
-                  <div
-                    key={product.id}
-                    className="flex items-center justify-between p-4 border rounded-lg"
-                  >
-                    <div className="flex items-center gap-4">
-                      <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
-                        <Package className="h-6 w-6" />
-                      </div>
-                      <div>
-                        <h3 className="font-medium">{product.name}</h3>
-                        <p className="text-sm text-muted-foreground">
-                          {product.category}
-                        </p>
-                      </div>
-                    </div>
-
-                    <div className="flex items-center gap-6">
-                      <div className="text-right">
-                        <p className="font-medium">{product.price}</p>
-                        <p className="text-sm text-muted-foreground">
-                          Stock: {product.stock}
-                        </p>
-                      </div>
-
-                      <Badge
-                        variant={
-                          product.status === "active"
-                            ? "default"
-                            : "destructive"
-                        }
-                      >
-                        {product.status === "active"
-                          ? "Active"
-                          : "Out of Stock"}
-                      </Badge>
-
-                      <div className="flex items-center gap-2">
-                        <Button variant="ghost" size="icon">
-                          <Edit className="h-4 w-4" />
-                        </Button>
-                        <Button variant="ghost" size="icon">
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold">Products</h2>
+          <p className="text-muted-foreground">Manage your product catalog</p>
         </div>
-      </DashboardLayout>
-    </ProtectedRoute>
+        <Button>
+          <Plus className="h-4 w-4 mr-2" />
+          Add Product
+        </Button>
+      </div>
+
+      {/* Search and Filters */}
+      <Card>
+        <CardContent className="pt-6">
+          <div className="flex items-center gap-4">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input placeholder="Search products..." className="pl-10" />
+            </div>
+            <Button variant="outline">Filter</Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Products Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Product List</CardTitle>
+          <CardDescription>All your products in one place</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {products.map((product) => (
+              <div
+                key={product.id}
+                className="flex items-center justify-between p-4 border rounded-lg"
+              >
+                <div className="flex items-center gap-4">
+                  <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
+                    <Package className="h-6 w-6" />
+                  </div>
+                  <div>
+                    <h3 className="font-medium">{product.name}</h3>
+                    <p className="text-sm text-muted-foreground">
+                      {product.category}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-6">
+                  <div className="text-right">
+                    <p className="font-medium">{product.price}</p>
+                    <p className="text-sm text-muted-foreground">
+                      Stock: {product.stock}
+                    </p>
+                  </div>
+
+                  <Badge
+                    variant={
+                      product.status === "active" ? "default" : "destructive"
+                    }
+                  >
+                    {product.status === "active" ? "Active" : "Out of Stock"}
+                  </Badge>
+
+                  <div className="flex items-center gap-2">
+                    <Button variant="ghost" size="icon">
+                      <Edit className="h-4 w-4" />
+                    </Button>
+                    <Button variant="ghost" size="icon">
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/src/app/vendor/tickets/page.tsx
+++ b/src/app/vendor/tickets/page.tsx
@@ -4,46 +4,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import {
-  BarChart3,
-  Users,
-  Package,
-  FileText,
-  Bell,
-  Ticket,
-  Plus,
-  Search,
-  MessageCircle,
-  Clock,
-} from "lucide-react";
-import { DashboardLayout } from "@/components/shared/dashboard-layout";
-import { ProtectedRoute } from "@/components/shared/protected-route";
-
-const vendorNavigation = [
-  {
-    name: "Dashboard",
-    href: "/dashboard",
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    name: "Products",
-    href: "/products",
-    icon: <Package className="h-4 w-4" />,
-  },
-  { name: "Clients", href: "/clients", icon: <Users className="h-4 w-4" /> },
-  {
-    name: "Invoices",
-    href: "/invoices",
-    icon: <FileText className="h-4 w-4" />,
-  },
-  { name: "Users", href: "/users", icon: <Users className="h-4 w-4" /> },
-  {
-    name: "Notifications",
-    href: "/notifications",
-    icon: <Bell className="h-4 w-4" />,
-  },
-  { name: "Tickets", href: "/tickets", icon: <Ticket className="h-4 w-4" /> },
-];
+import { Ticket, Plus, Search, MessageCircle, Clock } from "lucide-react";
 
 const tickets = [
   {
@@ -78,97 +39,93 @@ const tickets = [
 
 export default function TicketsPage() {
   return (
-    <ProtectedRoute requiredRole="vendor">
-      <DashboardLayout title="Support Tickets" navigation={vendorNavigation}>
-        <div className="space-y-6">
-          {/* Header */}
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-2xl font-bold">Support Tickets</h2>
-              <p className="text-muted-foreground">
-                Get help with your account and technical issues
-              </p>
-            </div>
-            <Button>
-              <Plus className="h-4 w-4 mr-2" />
-              Create Ticket
-            </Button>
-          </div>
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold">Support Tickets</h2>
+          <p className="text-muted-foreground">
+            Get help with your account and technical issues
+          </p>
+        </div>
+        <Button>
+          <Plus className="h-4 w-4 mr-2" />
+          Create Ticket
+        </Button>
+      </div>
 
-          {/* Search */}
-          <Card>
+      {/* Search */}
+      <Card>
+        <CardContent className="pt-6">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input placeholder="Search tickets..." className="pl-10" />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Tickets List */}
+      <div className="space-y-4">
+        {tickets.map((ticket) => (
+          <Card key={ticket.id}>
             <CardContent className="pt-6">
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                <Input placeholder="Search tickets..." className="pl-10" />
+              <div className="flex items-start justify-between">
+                <div className="flex items-start gap-4">
+                  <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
+                    <Ticket className="h-6 w-6" />
+                  </div>
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2 mb-2">
+                      <h3 className="font-medium">{ticket.title}</h3>
+                      <Badge
+                        variant={
+                          ticket.priority === "high"
+                            ? "destructive"
+                            : ticket.priority === "medium"
+                              ? "default"
+                              : "secondary"
+                        }
+                      >
+                        {ticket.priority}
+                      </Badge>
+                    </div>
+                    <p className="text-sm text-muted-foreground mb-3">
+                      {ticket.description}
+                    </p>
+                    <div className="flex items-center gap-4 text-xs text-muted-foreground">
+                      <span className="flex items-center gap-1">
+                        <Clock className="h-3 w-3" />
+                        Created: {ticket.created}
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <MessageCircle className="h-3 w-3" />
+                        Updated: {ticket.lastUpdate}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-3">
+                  <Badge
+                    variant={
+                      ticket.status === "open"
+                        ? "destructive"
+                        : ticket.status === "in_progress"
+                          ? "default"
+                          : "secondary"
+                    }
+                  >
+                    {ticket.status.replace("_", " ")}
+                  </Badge>
+                  <Button variant="outline" size="sm">
+                    View Details
+                  </Button>
+                </div>
               </div>
             </CardContent>
           </Card>
-
-          {/* Tickets List */}
-          <div className="space-y-4">
-            {tickets.map((ticket) => (
-              <Card key={ticket.id}>
-                <CardContent className="pt-6">
-                  <div className="flex items-start justify-between">
-                    <div className="flex items-start gap-4">
-                      <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
-                        <Ticket className="h-6 w-6" />
-                      </div>
-                      <div className="flex-1">
-                        <div className="flex items-center gap-2 mb-2">
-                          <h3 className="font-medium">{ticket.title}</h3>
-                          <Badge
-                            variant={
-                              ticket.priority === "high"
-                                ? "destructive"
-                                : ticket.priority === "medium"
-                                ? "default"
-                                : "secondary"
-                            }
-                          >
-                            {ticket.priority}
-                          </Badge>
-                        </div>
-                        <p className="text-sm text-muted-foreground mb-3">
-                          {ticket.description}
-                        </p>
-                        <div className="flex items-center gap-4 text-xs text-muted-foreground">
-                          <span className="flex items-center gap-1">
-                            <Clock className="h-3 w-3" />
-                            Created: {ticket.created}
-                          </span>
-                          <span className="flex items-center gap-1">
-                            <MessageCircle className="h-3 w-3" />
-                            Updated: {ticket.lastUpdate}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-
-                    <div className="flex items-center gap-3">
-                      <Badge
-                        variant={
-                          ticket.status === "open"
-                            ? "destructive"
-                            : ticket.status === "in_progress"
-                            ? "default"
-                            : "secondary"
-                        }
-                      >
-                        {ticket.status.replace("_", " ")}
-                      </Badge>
-                      <Button variant="outline" size="sm">
-                        View Details
-                      </Button>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </div>
-      </DashboardLayout>
-    </ProtectedRoute>
+        ))}
+      </div>
+    </div>
   );
 }

--- a/src/app/vendor/users/page.tsx
+++ b/src/app/vendor/users/page.tsx
@@ -10,47 +10,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import {
-  BarChart3,
-  Users,
-  Package,
-  FileText,
-  Bell,
-  Ticket,
-  Plus,
-  Search,
-  Shield,
-  Edit,
-  Trash2,
-} from "lucide-react";
-import { DashboardLayout } from "@/components/shared/dashboard-layout";
-import { ProtectedRoute } from "@/components/shared/protected-route";
-
-const vendorNavigation = [
-  {
-    name: "Dashboard",
-    href: "/dashboard",
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    name: "Products",
-    href: "/products",
-    icon: <Package className="h-4 w-4" />,
-  },
-  { name: "Clients", href: "/clients", icon: <Users className="h-4 w-4" /> },
-  {
-    name: "Invoices",
-    href: "/invoices",
-    icon: <FileText className="h-4 w-4" />,
-  },
-  { name: "Users", href: "/users", icon: <Users className="h-4 w-4" /> },
-  {
-    name: "Notifications",
-    href: "/notifications",
-    icon: <Bell className="h-4 w-4" />,
-  },
-  { name: "Tickets", href: "/tickets", icon: <Ticket className="h-4 w-4" /> },
-];
+import { Users, Plus, Search, Shield, Edit, Trash2 } from "lucide-react";
 
 const users = [
   {
@@ -81,95 +41,89 @@ const users = [
 
 export default function UsersPage() {
   return (
-    <ProtectedRoute requiredRole="vendor">
-      <DashboardLayout title="Users Management" navigation={vendorNavigation}>
-        <div className="space-y-6">
-          {/* Header */}
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-2xl font-bold">Users</h2>
-              <p className="text-muted-foreground">
-                Manage team members and permissions
-              </p>
-            </div>
-            <Button>
-              <Plus className="h-4 w-4 mr-2" />
-              Add User
-            </Button>
-          </div>
-
-          {/* Search */}
-          <Card>
-            <CardContent className="pt-6">
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                <Input placeholder="Search users..." className="pl-10" />
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Users Table */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Team Members</CardTitle>
-              <CardDescription>
-                All users with access to your vendor account
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                {users.map((user) => (
-                  <div
-                    key={user.id}
-                    className="flex items-center justify-between p-4 border rounded-lg"
-                  >
-                    <div className="flex items-center gap-4">
-                      <div className="w-12 h-12 bg-muted rounded-full flex items-center justify-center">
-                        <Users className="h-6 w-6" />
-                      </div>
-                      <div>
-                        <h3 className="font-medium">{user.name}</h3>
-                        <p className="text-sm text-muted-foreground">
-                          {user.email}
-                        </p>
-                      </div>
-                    </div>
-
-                    <div className="flex items-center gap-6">
-                      <div className="text-right">
-                        <div className="flex items-center gap-2">
-                          <Shield className="h-4 w-4 text-muted-foreground" />
-                          <span className="font-medium">{user.role}</span>
-                        </div>
-                        <p className="text-sm text-muted-foreground">
-                          Last login: {user.lastLogin}
-                        </p>
-                      </div>
-
-                      <Badge
-                        variant={
-                          user.status === "active" ? "default" : "secondary"
-                        }
-                      >
-                        {user.status}
-                      </Badge>
-
-                      <div className="flex items-center gap-2">
-                        <Button variant="ghost" size="icon">
-                          <Edit className="h-4 w-4" />
-                        </Button>
-                        <Button variant="ghost" size="icon">
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold">Users</h2>
+          <p className="text-muted-foreground">
+            Manage team members and permissions
+          </p>
         </div>
-      </DashboardLayout>
-    </ProtectedRoute>
+        <Button>
+          <Plus className="h-4 w-4 mr-2" />
+          Add User
+        </Button>
+      </div>
+
+      {/* Search */}
+      <Card>
+        <CardContent className="pt-6">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input placeholder="Search users..." className="pl-10" />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Users Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Team Members</CardTitle>
+          <CardDescription>
+            All users with access to your vendor account
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {users.map((user) => (
+              <div
+                key={user.id}
+                className="flex items-center justify-between p-4 border rounded-lg"
+              >
+                <div className="flex items-center gap-4">
+                  <div className="w-12 h-12 bg-muted rounded-full flex items-center justify-center">
+                    <Users className="h-6 w-6" />
+                  </div>
+                  <div>
+                    <h3 className="font-medium">{user.name}</h3>
+                    <p className="text-sm text-muted-foreground">
+                      {user.email}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-6">
+                  <div className="text-right">
+                    <div className="flex items-center gap-2">
+                      <Shield className="h-4 w-4 text-muted-foreground" />
+                      <span className="font-medium">{user.role}</span>
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      Last login: {user.lastLogin}
+                    </p>
+                  </div>
+
+                  <Badge
+                    variant={user.status === "active" ? "default" : "secondary"}
+                  >
+                    {user.status}
+                  </Badge>
+
+                  <div className="flex items-center gap-2">
+                    <Button variant="ghost" size="icon">
+                      <Edit className="h-4 w-4" />
+                    </Button>
+                    <Button variant="ghost" size="icon">
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove ProtectedRoute and DashboardLayout wrappers from all route page components
- drop per-page navigation arrays and unused icons

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f00c73c548322b346c3bfc50afba5