### PR TITLE
feat: derive sidebar data from dashboard layout

### DIFF
--- a/src/components/shared/app-sidebar.tsx
+++ b/src/components/shared/app-sidebar.tsx
@@ -3,23 +3,7 @@
 "use client";
 
 import * as React from "react";
-import {
-  IconCamera,
-  IconChartBar,
-  IconDashboard,
-  IconDatabase,
-  IconFileAi,
-  IconFileDescription,
-  IconFileWord,
-  IconFolder,
-  IconHelp,
-  IconInnerShadowTop,
-  IconListDetails,
-  IconReport,
-  IconSearch,
-  IconSettings,
-  IconUsers,
-} from "@tabler/icons-react";
+import { IconInnerShadowTop } from "@tabler/icons-react";
 
 import { NavDocuments } from "./nav-documents";
 import { NavMain } from "./nav-main";
@@ -35,124 +19,34 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 
-const data = {
+interface SidebarData {
   user: {
-    name: "shadcn",
-    email: "m@example.com",
-    avatar: "/avatars/shadcn.jpg",
-  },
-  navMain: [
-    {
-      title: "Dashboard",
-      url: "#",
-      icon: IconDashboard,
-    },
-    {
-      title: "Lifecycle",
-      url: "#",
-      icon: IconListDetails,
-    },
-    {
-      title: "Analytics",
-      url: "#",
-      icon: IconChartBar,
-    },
-    {
-      title: "Projects",
-      url: "#",
-      icon: IconFolder,
-    },
-    {
-      title: "Team",
-      url: "#",
-      icon: IconUsers,
-    },
-  ],
-  navClouds: [
-    {
-      title: "Capture",
-      icon: IconCamera,
-      isActive: true,
-      url: "#",
-      items: [
-        {
-          title: "Active Proposals",
-          url: "#",
-        },
-        {
-          title: "Archived",
-          url: "#",
-        },
-      ],
-    },
-    {
-      title: "Proposal",
-      icon: IconFileDescription,
-      url: "#",
-      items: [
-        {
-          title: "Active Proposals",
-          url: "#",
-        },
-        {
-          title: "Archived",
-          url: "#",
-        },
-      ],
-    },
-    {
-      title: "Prompts",
-      icon: IconFileAi,
-      url: "#",
-      items: [
-        {
-          title: "Active Proposals",
-          url: "#",
-        },
-        {
-          title: "Archived",
-          url: "#",
-        },
-      ],
-    },
-  ],
-  navSecondary: [
-    {
-      title: "Settings",
-      url: "#",
-      icon: IconSettings,
-    },
-    {
-      title: "Get Help",
-      url: "#",
-      icon: IconHelp,
-    },
-    {
-      title: "Search",
-      url: "#",
-      icon: IconSearch,
-    },
-  ],
-  documents: [
-    {
-      name: "Data Library",
-      url: "#",
-      icon: IconDatabase,
-    },
-    {
-      name: "Reports",
-      url: "#",
-      icon: IconReport,
-    },
-    {
-      name: "Word Assistant",
-      url: "#",
-      icon: IconFileWord,
-    },
-  ],
-};
+    name: string;
+    email: string;
+    avatar: string;
+  };
+  navMain: {
+    title: string;
+    url: string;
+    icon?: React.ReactNode;
+  }[];
+  navSecondary: {
+    title: string;
+    url: string;
+    icon: React.ComponentType<{ className?: string }>;
+  }[];
+  documents: {
+    name: string;
+    url: string;
+    icon: React.ComponentType<{ className?: string }>;
+  }[];
+}
 
-export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+interface AppSidebarProps extends React.ComponentProps<typeof Sidebar> {
+  data: SidebarData;
+}
+
+export function AppSidebar({ data, ...props }: AppSidebarProps) {
   return (
     <Sidebar collapsible="offcanvas" {...props}>
       <SidebarHeader>

--- a/src/components/shared/dashboard-layout.tsx
+++ b/src/components/shared/dashboard-layout.tsx
@@ -3,10 +3,16 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { Button } from "@/components/ui/button";
-import { LogOut, Menu } from "lucide-react";
-import { useAuth } from "./auth-provider";
 import React from "react";
+import {
+  IconDatabase,
+  IconFileWord,
+  IconHelp,
+  IconReport,
+  IconSearch,
+  IconSettings,
+} from "@tabler/icons-react";
+import { useAuth } from "./auth-provider";
 import { SidebarInset } from "../ui/sidebar";
 import { SiteHeader } from "./site-header";
 import { AppSidebar } from "./app-sidebar";
@@ -23,14 +29,36 @@ interface DashboardLayoutProps {
 
 export function DashboardLayout({
   children,
-  title,
   navigation,
 }: DashboardLayoutProps) {
-  const { user, logout } = useAuth();
+  const { user } = useAuth();
+
+  const sidebarData = {
+    user: {
+      name: user?.name ?? "",
+      email: user?.email ?? "",
+      avatar: "/avatars/shadcn.jpg",
+    },
+    navMain: navigation.map((item) => ({
+      title: item.name,
+      url: item.href,
+      icon: item.icon,
+    })),
+    navSecondary: [
+      { title: "Settings", url: "#", icon: IconSettings },
+      { title: "Get Help", url: "#", icon: IconHelp },
+      { title: "Search", url: "#", icon: IconSearch },
+    ],
+    documents: [
+      { name: "Data Library", url: "#", icon: IconDatabase },
+      { name: "Reports", url: "#", icon: IconReport },
+      { name: "Word Assistant", url: "#", icon: IconFileWord },
+    ],
+  };
 
   return (
     <React.Fragment>
-      <AppSidebar variant="inset" />
+      <AppSidebar variant="inset" data={sidebarData} />
       <SidebarInset>
         <SiteHeader />
         <div className="p-4">{children}</div>

--- a/src/components/shared/nav-main.tsx
+++ b/src/components/shared/nav-main.tsx
@@ -2,7 +2,8 @@
 
 "use client";
 
-import { IconCirclePlusFilled, IconMail, type Icon } from "@tabler/icons-react";
+import { IconCirclePlusFilled, IconMail } from "@tabler/icons-react";
+import type { ReactNode } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -19,7 +20,7 @@ export function NavMain({
   items: {
     title: string;
     url: string;
-    icon?: Icon;
+    icon?: ReactNode;
   }[];
 }) {
   return (
@@ -48,7 +49,7 @@ export function NavMain({
           {items.map((item) => (
             <SidebarMenuItem key={item.title}>
               <SidebarMenuButton tooltip={item.title}>
-                {item.icon && <item.icon />}
+                {item.icon}
                 <span>{item.title}</span>
               </SidebarMenuButton>
             </SidebarMenuItem>


### PR DESCRIPTION
## Summary
- refactor `AppSidebar` to consume structured data from parent instead of static config
- adjust `NavMain` to accept ReactNode icons
- build sidebar data in `DashboardLayout` and pass to sidebar component

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689f08737bc88322a74d3e9b2952a818