### PR TITLE
feat: add theme and language toggle

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,9 +3,11 @@
 import type React from "react";
 import type { Metadata } from "next";
 import { Geist } from "next/font/google";
+import { ThemeProvider } from "next-themes";
 
 import "./globals.css";
 import { AuthProvider } from "@/components/shared/auth-provider";
+import { LanguageProvider } from "@/contexts/language-context";
 
 export const metadata: Metadata = {
   title: "Multi-Tenant Dashboard",
@@ -23,10 +25,14 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={geist.className}>
+    <html lang="en" suppressHydrationWarning className={geist.className}>
       <head></head>
       <body>
-        <AuthProvider>{children}</AuthProvider>
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+          <LanguageProvider>
+            <AuthProvider>{children}</AuthProvider>
+          </LanguageProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,7 @@
 /** @format */
 
+"use client";
+
 import { LoginForm } from "@/components/shared/login-form";
 import {
   Card,
@@ -8,17 +10,17 @@ import {
   CardDescription,
   CardContent,
 } from "@/components/ui/card";
+import { useLanguage } from "@/contexts/language-context";
 import type React from "react";
 
 export default function LoginPage() {
+  const { t } = useLanguage();
   return (
     <div className="min-h-screen flex items-center justify-center bg-muted/50">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
-          <CardTitle className="text-2xl font-bold">Login Dashboard</CardTitle>
-          <CardDescription>
-            Masuk ke dashboard sesuai dengan role Anda
-          </CardDescription>
+          <CardTitle className="text-2xl font-bold">{t("login")}</CardTitle>
+          <CardDescription>{t("loginDescription")}</CardDescription>
         </CardHeader>
         <CardContent>
           <LoginForm />

--- a/src/components/shared/language-toggle.tsx
+++ b/src/components/shared/language-toggle.tsx
@@ -1,0 +1,15 @@
+/** @format */
+
+"use client";
+
+import { useLanguage } from "@/contexts/language-context";
+import { Button } from "@/components/ui/button";
+
+export function LanguageToggle() {
+  const { lang, toggleLanguage } = useLanguage();
+  return (
+    <Button variant="ghost" size="sm" onClick={toggleLanguage}>
+      {lang.toUpperCase()}
+    </Button>
+  );
+}

--- a/src/components/shared/login-form.tsx
+++ b/src/components/shared/login-form.tsx
@@ -20,8 +20,10 @@ import {
   SelectValue,
 } from "../ui/select";
 import { Button } from "../ui/button";
+import { useLanguage } from "@/contexts/language-context";
 
 export function LoginForm() {
+  const { t } = useLanguage();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [role, setRole] = useState<UserRole | "">("");
@@ -40,14 +42,14 @@ export function LoginForm() {
       const session = await signIn(email, password, role);
 
       if (!session) {
-        setError("Email, password, atau role tidak valid");
+        setError(t("loginFailed"));
         return;
       }
 
       // Redirect based on role
       router.push(`/${role}/dashboard`);
     } catch {
-      setError("Terjadi kesalahan saat login");
+      setError(t("loginFailed"));
     } finally {
       setLoading(false);
     }
@@ -62,7 +64,7 @@ export function LoginForm() {
       )}
 
       <div className="space-y-2">
-        <Label htmlFor="email">Email</Label>
+        <Label htmlFor="email">{t("email")}</Label>
         <Input
           id="email"
           type="email"
@@ -75,7 +77,7 @@ export function LoginForm() {
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor="password">Password</Label>
+        <Label htmlFor="password">{t("password")}</Label>
         <Input
           id="password"
           type="password"
@@ -111,7 +113,7 @@ export function LoginForm() {
       </div>
 
       <Button type="submit" className="w-full" disabled={loading}>
-        {loading ? "Memproses..." : "Masuk"}
+        {loading ? `${t("signIn")}...` : t("signIn")}
       </Button>
 
       <div className="text-sm text-muted-foreground space-y-1">

--- a/src/components/shared/site-header.tsx
+++ b/src/components/shared/site-header.tsx
@@ -1,10 +1,16 @@
 /** @format */
 
+"use client";
+
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { SidebarTrigger } from "@/components/ui/sidebar";
+import { ThemeToggle } from "./theme-toggle";
+import { LanguageToggle } from "./language-toggle";
+import { useLanguage } from "@/contexts/language-context";
 
 export function SiteHeader() {
+  const { t } = useLanguage();
   return (
     <header className="flex h-(--header-height) shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-(--header-height)">
       <div className="flex w-full items-center gap-1 px-4 lg:gap-2 lg:px-6">
@@ -13,7 +19,7 @@ export function SiteHeader() {
           orientation="vertical"
           className="mx-2 data-[orientation=vertical]:h-4"
         />
-        <h1 className="text-base font-medium">Documents</h1>
+        <h1 className="text-base font-medium">{t("documents")}</h1>
         <div className="ml-auto flex items-center gap-2">
           <Button variant="ghost" asChild size="sm" className="hidden sm:flex">
             <a
@@ -22,9 +28,11 @@ export function SiteHeader() {
               target="_blank"
               className="dark:text-foreground"
             >
-              GitHub
+              {t("github")}
             </a>
           </Button>
+          <ThemeToggle />
+          <LanguageToggle />
         </div>
       </div>
     </header>

--- a/src/components/shared/theme-toggle.tsx
+++ b/src/components/shared/theme-toggle.tsx
@@ -1,0 +1,25 @@
+/** @format */
+
+"use client";
+
+import { Sun, Moon } from "lucide-react";
+import { useTheme } from "next-themes";
+
+import { Switch } from "@/components/ui/switch";
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const isDark = theme === "dark";
+
+  return (
+    <div className="flex items-center gap-2">
+      <Sun className="h-4 w-4" />
+      <Switch
+        checked={isDark}
+        onCheckedChange={(checked) => setTheme(checked ? "dark" : "light")}
+        aria-label="Toggle dark mode"
+      />
+      <Moon className="h-4 w-4" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add ThemeProvider and LanguageProvider wrappers
- introduce theme and language toggles in header
- translate login page and form using language context

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f1c6e5400832282b45cb3bf35e4c7