### PR TITLE
docs: add koperasi page documentation

### DIFF
--- a/docs/koperasi/dashboard.md
+++ b/docs/koperasi/dashboard.md
@@ -1,0 +1,39 @@
+# Dashboard Koperasi
+
+- **Path**: `/koperasi/dashboard`
+- **Tujuan Halaman**: Menampilkan ringkasan statistik dan aktivitas koperasi.
+- **Elemen Fungsional Utama**:
+  - Kartu statistik untuk anggota, simpanan, pinjaman, dan SHU.
+  - Daftar aktivitas terbaru.
+  - Aksi cepat: tambah anggota, setoran simpanan, proses pinjaman, lihat laporan.
+  - Agenda mendatang seperti RAT dan pembagian SHU.
+- **Endpoint**:
+  - `GET /api/koperasi/dashboard/stats`
+  - `GET /api/koperasi/activities`
+  - `GET /api/koperasi/agendas`
+- **Format Data**:
+
+  ```json
+  {
+    "stats": {
+      "anggota": 0,
+      "simpanan": 0,
+      "pinjaman": 0,
+      "shu": 0
+    },
+    "activities": [
+      {
+        "id": 0,
+        "deskripsi": "string",
+        "tanggal": "YYYY-MM-DD"
+      }
+    ],
+    "agendas": [
+      {
+        "id": 0,
+        "judul": "string",
+        "tanggal": "YYYY-MM-DD"
+      }
+    ]
+  }
+  ```

--- a/docs/koperasi/keanggotaan.md
+++ b/docs/koperasi/keanggotaan.md
@@ -1,0 +1,31 @@
+# Keanggotaan Koperasi
+
+- **Path**: `/koperasi/keanggotaan`
+- **Tujuan Halaman**: Mengelola data dan aktivitas anggota koperasi.
+- **Elemen Fungsional Utama**:
+  - Tombol untuk menambah anggota baru.
+  - Kartu statistik total anggota, anggota aktif, dan anggota baru.
+  - Pencarian anggota.
+  - Tabel anggota dengan informasi simpanan, status, serta aksi lihat dan edit.
+- **Endpoint**:
+  - `GET /api/koperasi/anggota/stats`
+  - `GET /api/koperasi/anggota`
+- **Format Data**:
+
+  ```json
+  {
+    "stats": {
+      "total": 0,
+      "aktif": 0,
+      "baru": 0
+    },
+    "anggota": [
+      {
+        "id": 0,
+        "nama": "string",
+        "simpanan": 0,
+        "status": "string"
+      }
+    ]
+  }
+  ```

--- a/docs/koperasi/pinjaman.md
+++ b/docs/koperasi/pinjaman.md
@@ -1,0 +1,34 @@
+# Pinjaman Koperasi
+
+- **Path**: `/koperasi/pinjaman`
+- **Tujuan Halaman**: Mengelola pengajuan dan status pinjaman anggota.
+- **Elemen Fungsional Utama**:
+  - Tombol pengajuan pinjaman baru.
+  - Kartu statistik total pinjaman, menunggu persetujuan, pinjaman aktif, dan tunggakan.
+  - Pencarian dan filter pinjaman.
+  - Tabel pinjaman dengan detail anggota, jumlah, sisa, angsuran, status, serta aksi lihat, setujui, atau tolak.
+- **Endpoint**:
+  - `GET /api/koperasi/pinjaman/stats`
+  - `GET /api/koperasi/pinjaman`
+- **Format Data**:
+
+  ```json
+  {
+    "stats": {
+      "total": 0,
+      "menunggu": 0,
+      "aktif": 0,
+      "tunggakan": 0
+    },
+    "pinjaman": [
+      {
+        "id": 0,
+        "anggota": "string",
+        "jumlah": 0,
+        "sisa": 0,
+        "angsuran": 0,
+        "status": "string"
+      }
+    ]
+  }
+  ```

--- a/docs/koperasi/rat.md
+++ b/docs/koperasi/rat.md
@@ -1,0 +1,36 @@
+# Rapat Anggota Tahunan (RAT)
+
+- **Path**: `/koperasi/rat`
+- **Tujuan Halaman**: Mengatur jadwal dan memantau pelaksanaan RAT.
+- **Elemen Fungsional Utama**:
+  - Tombol untuk menjadwalkan RAT.
+  - Detail RAT mendatang: tanggal, waktu, lokasi, dan konfirmasi kehadiran.
+  - Statistik RAT: total anggota, konfirmasi kehadiran, kuorum, dan hari tersisa.
+  - Riwayat RAT sebelumnya beserta persentase kehadiran dan status.
+- **Endpoint**:
+  - `GET /api/koperasi/rat/upcoming`
+  - `GET /api/koperasi/rat/history`
+- **Format Data**:
+
+  ```json
+  {
+    "upcoming": {
+      "tanggal": "YYYY-MM-DD",
+      "waktu": "HH:MM",
+      "lokasi": "string"
+    },
+    "stats": {
+      "totalAnggota": 0,
+      "konfirmasi": 0,
+      "kuorum": 0,
+      "hariTersisa": 0
+    },
+    "history": [
+      {
+        "tahun": 0,
+        "hadir": 0,
+        "status": "string"
+      }
+    ]
+  }
+  ```

--- a/docs/koperasi/shu.md
+++ b/docs/koperasi/shu.md
@@ -1,0 +1,37 @@
+# Sisa Hasil Usaha (SHU)
+
+- **Path**: `/koperasi/shu`
+- **Tujuan Halaman**: Mengelola perhitungan dan pembagian SHU kepada anggota.
+- **Elemen Fungsional Utama**:
+  - Tombol untuk menghitung SHU dan mengekspor data.
+  - Kartu ringkasan total SHU, bagian anggota, dan bagian modal.
+  - Riwayat SHU per tahun.
+  - Pembagian SHU per anggota beserta status pembayaran.
+- **Endpoint**:
+  - `GET /api/koperasi/shu/stats`
+  - `GET /api/koperasi/shu/history`
+  - `GET /api/koperasi/shu/distribusi`
+- **Format Data**:
+
+  ```json
+  {
+    "stats": {
+      "total": 0,
+      "bagianAnggota": 0,
+      "bagianModal": 0
+    },
+    "history": [
+      {
+        "tahun": 0,
+        "total": 0
+      }
+    ],
+    "distribusi": [
+      {
+        "anggota": "string",
+        "jumlah": 0,
+        "status": "string"
+      }
+    ]
+  }
+  ```

--- a/docs/koperasi/simpanan.md
+++ b/docs/koperasi/simpanan.md
@@ -1,0 +1,33 @@
+# Simpanan Koperasi
+
+- **Path**: `/koperasi/simpanan`
+- **Tujuan Halaman**: Mencatat setoran dan penarikan simpanan anggota.
+- **Elemen Fungsional Utama**:
+  - Tombol setoran dan penarikan simpanan.
+  - Kartu statistik total simpanan, simpanan pokok, simpanan wajib, dan simpanan sukarela.
+  - Pencarian transaksi.
+  - Tabel riwayat transaksi dengan jenis, jumlah, saldo, dan aksi detail.
+- **Endpoint**:
+  - `GET /api/koperasi/simpanan/stats`
+  - `GET /api/koperasi/simpanan`
+- **Format Data**:
+
+  ```json
+  {
+    "stats": {
+      "total": 0,
+      "pokok": 0,
+      "wajib": 0,
+      "sukarela": 0
+    },
+    "transaksi": [
+      {
+        "id": 0,
+        "jenis": "string",
+        "jumlah": 0,
+        "saldo": 0,
+        "tanggal": "YYYY-MM-DD"
+      }
+    ]
+  }
+  ```


### PR DESCRIPTION
## Summary
- document dashboard koperasi page with paths, purpose, main features, API endpoints, and data formats
- add docs for keanggotaan, RAT, pinjaman, SHU, and simpanan pages including endpoints and JSON structures

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f3d775658832281ae456c6937a51d