### PR TITLE
docs: add login and role documentation

### DIFF
--- a/docs/auth/login.md
+++ b/docs/auth/login.md
@@ -1,0 +1,46 @@
+# Login
+
+## Route
+`/login`
+
+Halaman ini menampilkan form masuk untuk seluruh tenant.
+
+### Form Field
+| Nama | Tipe | Deskripsi |
+| --- | --- | --- |
+| email | string | Alamat email terdaftar |
+| password | string | Password akun |
+| role | enum | Pilih salah satu: `vendor`, `koperasi`, `umkm`, `bumdes` |
+
+### Endpoint & Format Data
+**Endpoint**: `POST /auth/login`
+
+**Request Body**
+```json
+{
+  "email": "user@example.com",
+  "password": "password",
+  "role": "vendor"
+}
+```
+
+**Response**
+```json
+{
+  "token": "jwt_token",
+  "user": {
+    "id": "1",
+    "email": "vendor@test.com",
+    "name": "Vendor User",
+    "role": "vendor",
+    "organizationId": "org1"
+  }
+}
+```
+
+### Alur Autentikasi
+1. Pengguna mengisi ketiga field di atas lalu mengirimkan form.
+2. Aplikasi memanggil fungsi `signIn` yang memverifikasi email, password, dan role.
+3. Jika valid, sesi (`auth-session`) dibuat dan disimpan di `localStorage` serta cookie.
+4. Pengguna diarahkan ke dashboard sesuai role (`/vendor/dashboard`, `/koperasi/dashboard`, `/umkm/dashboard`, atau `/bumdes/dashboard`).
+5. Jika gagal, tampil pesan kesalahan.

--- a/docs/auth/role.md
+++ b/docs/auth/role.md
@@ -1,0 +1,24 @@
+# Role
+
+## Endpoint
+`PATCH /users/{id}/role`
+
+### Fitur
+- Mengubah role pengguna tertentu.
+- Menentukan akses dashboard yang dimiliki pengguna (vendor, koperasi, umkm, bumdes).
+
+### Payload
+```json
+{
+  "role": "vendor|koperasi|umkm|bumdes"
+}
+```
+
+### Response
+```json
+{
+  "id": "1",
+  "email": "user@test.com",
+  "role": "vendor"
+}
+```


### PR DESCRIPTION
## Summary
- document /login route, form fields, auth flow, and backend endpoint with request/response format
- document role endpoint payload and response

## Testing
- ⚠️ `npm test` (missing script: "test")
- ✅ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f3d7496f0832286d82b55b26732fb