### PR TITLE
docs: add UMKM page documentation

### DIFF
--- a/docs/umkm/dashboard.md
+++ b/docs/umkm/dashboard.md
@@ -1,0 +1,31 @@
+# Dashboard
+
+**Path:** `/umkm/dashboard`
+
+**Deskripsi:** Halaman beranda UMKM yang menampilkan ringkasan penjualan, stok, dan aktivitas terbaru.
+
+**Komponen Utama:**
+- Kartu statistik penjualan, total produk, transaksi, dan stok menipis.
+- Daftar transaksi terbaru.
+- Aksi cepat ke POS, Inventaris, Harga Bertingkat, dan Laporan.
+- Peringatan produk dengan stok rendah.
+
+**Endpoint:** `GET /api/umkm/dashboard`
+
+**Format Data:**
+```json
+{
+  "stats": {
+    "penjualan": 0,
+    "produk": 0,
+    "transaksi": 0,
+    "stokMenipis": 0
+  },
+  "transaksiTerbaru": [
+    { "id": 1, "tanggal": "2024-01-01", "total": 0 }
+  ],
+  "stokRendah": [
+    { "id": 1, "nama": "Produk A", "stok": 0 }
+  ]
+}
+```

--- a/docs/umkm/harga-bertingkat.md
+++ b/docs/umkm/harga-bertingkat.md
@@ -1,0 +1,26 @@
+# Harga Bertingkat
+
+**Path:** `/umkm/harga-bertingkat`
+
+**Deskripsi:** Halaman untuk mengelola harga produk berdasarkan tingkat pelanggan.
+
+**Komponen Utama:**
+- Daftar tingkat pelanggan lengkap dengan diskon dan anggota.
+- Pencarian produk.
+- Tabel harga produk untuk setiap tingkat pelanggan.
+
+**Endpoint:** `GET /api/umkm/pricing-tiers`
+
+**Format Data:**
+```json
+[
+  {
+    "tier": "Gold",
+    "diskon": 10,
+    "anggota": 25,
+    "produk": [
+      { "id": 1, "nama": "Produk A", "harga": 9000 }
+    ]
+  }
+]
+```

--- a/docs/umkm/inventaris.md
+++ b/docs/umkm/inventaris.md
@@ -1,0 +1,27 @@
+# Inventaris
+
+**Path:** `/umkm/inventaris`
+
+**Deskripsi:** Halaman untuk mengelola daftar produk, stok, dan informasi inventaris.
+
+**Komponen Utama:**
+- Kartu statistik total produk, ketersediaan, stok rendah, dan stok habis.
+- Pencarian serta filter kategori dan status.
+- Tabel produk dengan detail stok, harga, status, dan aksi.
+
+**Endpoint:** `GET /api/umkm/inventory`
+
+**Format Data:**
+```json
+{
+  "stats": {
+    "totalProduk": 0,
+    "ketersediaan": 0,
+    "stokRendah": 0,
+    "stokHabis": 0
+  },
+  "produk": [
+    { "id": 1, "nama": "Produk A", "stok": 10, "harga": 10000, "status": "aktif" }
+  ]
+}
+```

--- a/docs/umkm/laporan.md
+++ b/docs/umkm/laporan.md
@@ -1,0 +1,28 @@
+# Laporan
+
+**Path:** `/umkm/laporan`
+
+**Deskripsi:** Halaman analisis penjualan dan performa usaha.
+
+**Komponen Utama:**
+- Kartu ringkasan pendapatan dan transaksi untuk berbagai periode.
+- Grafik tren penjualan dan distribusi kategori produk.
+- Daftar produk terlaris beserta tren penjualan.
+
+**Endpoint:** `GET /api/umkm/reports/sales`
+
+**Format Data:**
+```json
+{
+  "ringkasan": {
+    "pendapatan": { "harian": 0, "bulanan": 0 },
+    "transaksi": { "harian": 0, "bulanan": 0 }
+  },
+  "trenPenjualan": [
+    { "tanggal": "2024-01-01", "total": 0 }
+  ],
+  "produkTerlaris": [
+    { "id": 1, "nama": "Produk A", "total": 0 }
+  ]
+}
+```

--- a/docs/umkm/pengaturan.md
+++ b/docs/umkm/pengaturan.md
@@ -1,0 +1,30 @@
+# Pengaturan
+
+**Path:** `/umkm/pengaturan`
+
+**Deskripsi:** Halaman untuk mengatur informasi usaha, preferensi POS, notifikasi, metode pembayaran, dan keamanan.
+
+**Komponen Utama:**
+- Formulir informasi usaha (nama, pemilik, kontak, alamat).
+- Pengaturan POS seperti cetak struk otomatis dan tarif pajak.
+- Pengaturan notifikasi stok, laporan, dan pengingat pembayaran.
+- Daftar metode pembayaran yang didukung.
+- Formulir pengubahan kata sandi.
+
+**Endpoint:** `GET /api/umkm/settings`
+
+**Format Data:**
+```json
+{
+  "usaha": {
+    "nama": "Toko A",
+    "pemilik": "Budi",
+    "kontak": "08123",
+    "alamat": "Jl. Contoh"
+  },
+  "pos": { "cetakStruk": true, "tarifPajak": 10 },
+  "notifikasi": { "stok": true, "laporan": true, "pengingatPembayaran": true },
+  "pembayaran": ["tunai", "transfer"],
+  "keamanan": { "lastChange": "2024-01-01" }
+}
+```

--- a/docs/umkm/pos.md
+++ b/docs/umkm/pos.md
@@ -1,0 +1,35 @@
+# POS
+
+**Path:** `/umkm/pos`
+
+**Deskripsi:** Halaman Point of Sale untuk proses transaksi penjualan.
+
+**Komponen Utama:**
+- Daftar produk dengan fitur pencarian.
+- Keranjang belanja dengan kontrol kuantitas dan penghapusan item.
+- Ringkasan pembayaran mencakup subtotal, pajak, dan total.
+- Tombol pembayaran tunai dan non-tunai serta opsi simpan draft.
+
+**Endpoint:**
+- `GET /api/umkm/pos/products`
+- `POST /api/umkm/pos/checkout`
+
+**Format Data (Produk):**
+```json
+[
+  { "id": 1, "nama": "Produk A", "harga": 10000, "stok": 5 }
+]
+```
+
+**Format Data (Checkout):**
+```json
+{
+  "items": [
+    { "id": 1, "qty": 2, "harga": 10000 }
+  ],
+  "subtotal": 20000,
+  "pajak": 2000,
+  "total": 22000,
+  "metodePembayaran": "tunai"
+}
+```


### PR DESCRIPTION
## Summary
- document UMKM dashboard page
- add docs for tiered pricing, inventory, reports, settings, and POS
- include required API endpoints and sample data formats for each page

## Testing
- `npm test` *(fails: Missing script: "test"; no tests configured)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f3d7482e48322a7ad56cd693806a1