### PR TITLE
docs: add request and response sections to login endpoint

### DIFF
--- a/docs/auth/login.md
+++ b/docs/auth/login.md
@@ -15,6 +15,20 @@ Halaman ini menampilkan form masuk untuk seluruh tenant.
 ### Endpoint & Format Data
 **Endpoint**: `POST /auth/login`
 
+#### Request
+- `email` (string): Alamat email terdaftar
+- `password` (string): Password akun
+- `role` (enum): Pilih salah satu: `vendor`, `koperasi`, `umkm`, `bumdes`
+
+#### Response
+- `token` (string): Token JWT
+- `user` (object):
+  - `id` (string): ID pengguna
+  - `email` (string): Email pengguna
+  - `name` (string): Nama pengguna
+  - `role` (string): Role pengguna
+  - `organizationId` (string): ID organisasi
+
 **Request Body**
 ```json
 {


### PR DESCRIPTION
## Summary
- document request fields for login endpoint
- document response fields for login endpoint

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689ff2129920832282ad9438df6b874f