### PR TITLE
docs: add request response for shu endpoints

### DIFF
--- a/docs/koperasi/shu.md
+++ b/docs/koperasi/shu.md
@@ -9,8 +9,22 @@
   - Pembagian SHU per anggota beserta status pembayaran.
 - **Endpoint**:
   - `GET /api/koperasi/shu/stats`
+    - **Request:** _tanpa body_
+    - **Response:**
+      - `total` - total SHU.
+      - `bagianAnggota` - bagian untuk anggota.
+      - `bagianModal` - bagian untuk modal.
   - `GET /api/koperasi/shu/history`
+    - **Request:** _tanpa body_
+    - **Response:**
+      - `tahun` - tahun perhitungan.
+      - `total` - total SHU per tahun.
   - `GET /api/koperasi/shu/distribusi`
+    - **Request:** _tanpa body_
+    - **Response:**
+      - `anggota` - nama anggota.
+      - `jumlah` - jumlah SHU yang diterima.
+      - `status` - status pembayaran.
 - **Format Data**:
 
   ```json


### PR DESCRIPTION
## Summary
- document request and response details for SHU stats, history, and distribusi endpoints

## Testing
- ⚠️ `npm test` (missing script: test)
- ✅ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ff92c9f90832293760f1373e2dd24