### PR TITLE
feat: replace axios with fetch for api service

### DIFF
--- a/docs/example/hooks/useUsers.ts
+++ b/docs/example/hooks/useUsers.ts
@@ -3,8 +3,7 @@ import { api } from '../services/api';
 
 export function useUsers() {
   const { data, error, mutate } = useSWR('/api/users', async (url: string) => {
-    const res = await api.get(url);
-    return res.data;
+    return api.get(url);
   });
 
   return {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,32 +1,60 @@
 /** @format */
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import axios from "axios";
 import { getSession } from "next-auth/react";
 
-const api = axios.create({
-  baseURL: "/api",
-});
+const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
 
-api.interceptors.request.use(async (config) => {
+export class ApiError extends Error {
+  status: number;
+  data: any;
+  constructor(status: number, data: any) {
+    super(`Request failed with status ${status}`);
+    this.name = "ApiError";
+    this.status = status;
+    this.data = data;
+  }
+}
+
+async function request(path: string, options: RequestInit = {}) {
   const session = await getSession();
   const token = (session as any)?.accessToken;
+  const headers = new Headers(options.headers);
   if (token) {
-    config.headers = config.headers ?? {};
-    (config.headers as any).Authorization = `Bearer ${token}`;
+    headers.set("Authorization", `Bearer ${token}`);
   }
-  return config;
-});
 
-api.interceptors.response.use(
-  (res) => res,
-  (err) => {
-    if (err.response?.status === 401) {
-      localStorage.removeItem("accessToken");
-      // Optional: redirect to login page
-    }
-    return Promise.reject(err);
+  let body = options.body;
+  if (body && typeof body !== "string" && !(body instanceof FormData)) {
+    headers.set("Content-Type", "application/json");
+    body = JSON.stringify(body);
   }
-);
+
+  const res = await fetch(`${BASE_URL}${path}`, { ...options, headers, body });
+
+  const contentType = res.headers.get("content-type");
+  const data = contentType && contentType.includes("application/json")
+    ? await res.json()
+    : await res.text();
+
+  if (!res.ok) {
+    if (res.status === 401) {
+      localStorage.removeItem("accessToken");
+    }
+    throw new ApiError(res.status, data);
+  }
+
+  return data;
+}
+
+export const api = {
+  get: (path: string, options?: RequestInit) =>
+    request(path, { ...options, method: "GET" }),
+  post: (path: string, body?: any, options?: RequestInit) =>
+    request(path, { ...options, method: "POST", body }),
+  put: (path: string, body?: any, options?: RequestInit) =>
+    request(path, { ...options, method: "PUT", body }),
+  delete: (path: string, options?: RequestInit) =>
+    request(path, { ...options, method: "DELETE" }),
+};
 
 export default api;

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,7 +1,7 @@
 import api from '@/services/api';
 
 export async function login(email: string, password: string) {
-  const { data } = await api.post('/auth/login', { email, password });
+  const data = await api.post('/auth/login', { email, password });
   localStorage.setItem('accessToken', data.token);
   return data;
 }


### PR DESCRIPTION
## Summary
- refactor API layer to use `fetch` with environment base URL
- add `ApiError` for non-2xx responses and update auth login
- adjust documentation examples to new API helper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4ac9ce7ac8322bfb47445a86bf6b4