### PR TITLE
feat: handle missing tenant domains

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "axios": "^1.11.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.23.12",
         "lucide-react": "^0.539.0",
         "next": "15.4.6",
         "next-auth": "^4.24.11",
@@ -4710,6 +4711,33 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.12.tgz",
+      "integrity": "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.12",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -6052,6 +6080,21 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "axios": "^1.11.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.23.12",
     "lucide-react": "^0.539.0",
     "next": "15.4.6",
     "next-auth": "^4.24.11",

--- a/src/app/tenant-not-found/page.tsx
+++ b/src/app/tenant-not-found/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { motion } from "framer-motion";
+import Link from "next/link";
+
+export default function TenantNotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-muted/30 p-6 text-center">
+      <motion.h1
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+        className="mb-4 text-3xl font-bold"
+      >
+        Organisasi tidak ditemukan
+      </motion.h1>
+      <motion.p
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.3 }}
+        className="mb-8 max-w-md text-muted-foreground"
+      >
+        Domain yang Anda akses belum terdaftar. Silakan hubungi administrator
+        untuk informasi lebih lanjut.
+      </motion.p>
+      <Link href="/login">
+        <motion.button
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.95 }}
+          className="rounded-md bg-primary px-6 py-2 text-white shadow"
+        >
+          Kembali ke Login
+        </motion.button>
+      </Link>
+    </div>
+  );
+}
+

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -85,6 +85,11 @@ export async function middleware(request: NextRequest) {
     return res;
   }
 
+  // Redirect to info page if tenant cannot be resolved
+  if (!tenantId && pathname !== "/tenant-not-found") {
+    return NextResponse.redirect(new URL("/tenant-not-found", request.url));
+  }
+
   // Get session from cookies
   const sessionCookie = request.cookies.get("auth-session");
   const session = sessionCookie ? JSON.parse(sessionCookie.value) : null;


### PR DESCRIPTION
## Summary
- redirect to tenant-not-found page when no tenant ID could be resolved
- add tenant not found page with Framer Motion animation
- install framer-motion dependency

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4b7e7aff0832295b3b73bd9157fee