### PR TITLE
refactor: integrate next-auth session

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,7 @@ import { Geist } from "next/font/google";
 import { ThemeProvider } from "next-themes";
 
 import "./globals.css";
-import { AuthProvider } from "@/components/shared/auth-provider";
+import SessionProviderWrapper from "@/components/session-provider";
 import { LanguageProvider } from "@/contexts/language-context";
 
 export const metadata: Metadata = {
@@ -28,11 +28,11 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning className={geist.className}>
       <head></head>
       <body>
-        <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
-          <LanguageProvider>
-            <AuthProvider>{children}</AuthProvider>
-          </LanguageProvider>
-        </ThemeProvider>
+        <SessionProviderWrapper>
+          <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+            <LanguageProvider>{children}</LanguageProvider>
+          </ThemeProvider>
+        </SessionProviderWrapper>
       </body>
     </html>
   );

--- a/src/components/shared/dashboard-layout.tsx
+++ b/src/components/shared/dashboard-layout.tsx
@@ -12,7 +12,7 @@ import {
   IconSearch,
   IconSettings,
 } from "@tabler/icons-react";
-import { useAuth } from "./auth-provider";
+import { useSession } from "next-auth/react";
 import { SidebarInset } from "../ui/sidebar";
 import { SiteHeader } from "./site-header";
 import { AppSidebar } from "./app-sidebar";
@@ -31,12 +31,12 @@ export function DashboardLayout({
   children,
   navigation,
 }: DashboardLayoutProps) {
-  const { user } = useAuth();
+  const { data: session } = useSession();
 
   const sidebarData = {
     user: {
-      name: user?.name ?? "",
-      email: user?.email ?? "",
+      name: session?.user?.name ?? "",
+      email: session?.user?.email ?? "",
       avatar: "/avatars/shadcn.jpg",
     },
     navMain: navigation.map((item) => ({

--- a/src/components/shared/login-form.tsx
+++ b/src/components/shared/login-form.tsx
@@ -5,7 +5,7 @@
 import type React from "react";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { signIn } from "@/lib/auth";
+import { login } from "@/services/auth";
 import type { UserRole } from "@/lib/types";
 import { Alert, AlertDescription } from "../ui/alert";
 import { Input } from "../ui/input";
@@ -39,13 +39,7 @@ export function LoginForm() {
     setError("");
 
     try {
-      const session = await signIn(email, password, role);
-
-      if (!session) {
-        setError(t("loginFailed"));
-        return;
-      }
-
+      await login(email, password);
       // Redirect based on role
       router.push(`/${role}/dashboard`);
     } catch {

--- a/src/components/shared/nav-user.tsx
+++ b/src/components/shared/nav-user.tsx
@@ -26,7 +26,7 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from "@/components/ui/sidebar";
-import { useAuth } from "./auth-provider";
+import { logout } from "@/services/auth";
 
 export function NavUser({
   user,
@@ -38,7 +38,6 @@ export function NavUser({
   };
 }) {
   const { isMobile } = useSidebar();
-  const { logout } = useAuth();
 
   return (
     <SidebarMenu>


### PR DESCRIPTION
## Summary
- wrap app in NextAuth SessionProviderWrapper
- switch login form to services/auth login
- replace custom auth hooks with `useSession` and logout service

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a534f69174832290edd6f8b9df0382