### PR TITLE
refactor: rename API base env

### DIFF
--- a/docs/example/services/api.ts
+++ b/docs/example/services/api.ts
@@ -23,7 +23,7 @@ async function request(path: string, options: RequestInit = {}) {
     body = JSON.stringify(body);
   }
 
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}${path}`, {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}${path}`, {
     ...options,
     headers,
     body,

--- a/docs/frontend/refresh_token.md
+++ b/docs/frontend/refresh_token.md
@@ -92,7 +92,7 @@ import axios, { AxiosError, AxiosRequestConfig } from 'axios';
 let accessToken: string | null = null;
 
 export const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
+  baseURL: process.env.NEXT_PUBLIC_API_URL,
 });
 
 api.interceptors.request.use((config: AxiosRequestConfig) => {
@@ -155,11 +155,11 @@ export function useUsers() {
 
 ### Konfigurasi Base URL
 
-`NEXT_PUBLIC_API_BASE_URL` dapat didefinisikan di `.env.local` agar
+`NEXT_PUBLIC_API_URL` dapat didefinisikan di `.env.local` agar
 axios menggunakan alamat yang sesuai:
 
 ```env
-NEXT_PUBLIC_API_BASE_URL=http://localhost:8080
+NEXT_PUBLIC_API_URL=http://localhost:8080
 ```
 
 ### Logout

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,10 +8,7 @@ export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const host = request.headers.get("host") ?? "";
 
-  const apiBase =
-    process.env.NEXT_PUBLIC_API_BASE_URL ??
-    process.env.NEXT_PUBLIC_API_URL ??
-    "";
+  const apiBase = process.env.NEXT_PUBLIC_API_URL ?? "";
 
   let tenantId = request.cookies.get("tenantId")?.value;
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -19,7 +19,7 @@ async function getTenantId(): Promise<string | null> {
   }
 }
 
-const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
 
 export class ApiError extends Error {
   status: number;

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -2,7 +2,7 @@
 
 import { getSession, signIn, signOut } from "next-auth/react";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
 
 export async function login(email: string, password: string) {
   const res = await signIn("credentials", {
@@ -17,7 +17,7 @@ export async function login(email: string, password: string) {
 }
 
 export async function logout() {
-  await fetch(`${API_BASE_URL}/auth/logout`, {
+  await fetch(`${API_URL}/auth/logout`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     credentials: "include",


### PR DESCRIPTION
## Summary
- use `NEXT_PUBLIC_API_URL` in auth and middleware services
- document updated env var for examples and refresh token docs

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module 'swr' from docs/example/hooks/useUsers.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a539c5d0188322afa3c0007843271e