### PR TITLE
fix: stabilize nextauth secret

### DIFF
--- a/src/__tests__/auth.spec.tsx
+++ b/src/__tests__/auth.spec.tsx
@@ -43,7 +43,8 @@ describe('auth flow', () => {
 
   it('redirects to dashboard based on role after successful login', async () => {
     (login as any).mockResolvedValue(loginFixture);
-    (getSession as any).mockResolvedValue({ user: { role: 'umkm' } });
+    // session should provide jenis_tenant to match LoginForm logic
+    (getSession as any).mockResolvedValue({ user: { jenis_tenant: 'umkm' } });
 
     const { getByLabelText, getByRole } = render(
       <LanguageProvider>

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -3,6 +3,7 @@ import { AuthOptions } from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 import { decodeJwt } from "jose"; // ✅ lebih aman dari manual base64 decode
 import { getTenantId } from "@/services/api";
+import { NEXTAUTH_SECRET } from "@/lib/env";
 
 export async function refreshAccessToken(token: any) {
   try {
@@ -125,5 +126,6 @@ export const authOptions: AuthOptions = {
     signOut: "/auth/login",
   },
 
-  secret: process.env.NEXTAUTH_SECRET,
+  // Use a constant secret to prevent runtime decryption errors
+  secret: NEXTAUTH_SECRET,
 };

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,15 @@
+/** @format */
+
+/**
+ * Centralized environment variables.
+ * Provides a stable fallback secret in development to avoid
+ * NextAuth decryption errors when `NEXTAUTH_SECRET` is missing.
+ */
+export const NEXTAUTH_SECRET =
+  process.env.NEXTAUTH_SECRET ?? "development_secret_change_me";
+
+if (!process.env.NEXTAUTH_SECRET) {
+  console.warn(
+    "NEXTAUTH_SECRET is not set. Using a fallback development secret."
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,6 +3,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { getToken } from "next-auth/jwt";
+import { NEXTAUTH_SECRET } from "@/lib/env";
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -56,7 +57,7 @@ export async function middleware(request: NextRequest) {
   // cek token NextAuth
   const token = await getToken({
     req: request,
-    secret: process.env.NEXTAUTH_SECRET,
+    secret: NEXTAUTH_SECRET,
   });
   const userRole = (token as any)?.jenis_tenant;
 


### PR DESCRIPTION
## Summary
- centralize NEXTAUTH_SECRET with development fallback
- apply secret to NextAuth options and middleware to avoid JWT decryption errors
- align auth flow test with LoginForm logic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6b1ad76848322951bf839e1643ac1