### PR TITLE
feat: add tenant management

### DIFF
--- a/docs/frontend/integration_guide.md
+++ b/docs/frontend/integration_guide.md
@@ -64,6 +64,10 @@ Semua endpoint berikut membutuhkan `Authorization` dan `X-Tenant-ID` kecuali dis
 
 Contoh proses menambah pengguna ke tenant dapat dilihat pada handler `AddUser`.
 
+### Alur UI Manajemen Tenant
+
+Dashboard kini menyediakan halaman **Tenants** di `/vendor/clients` untuk menampilkan daftar tenant dan membuat tenant baru. Klik salah satu tenant akan membuka halaman detail `/vendor/clients/[id]` yang memuat form informasi dasar, toggle status aktif, daftar pengguna beserta form penambahan pengguna, serta daftar modul yang dapat diaktif/nonaktifkan.
+
 ## Manajemen Role & Permission
 | Endpoint | Method | Body |
 |----------|--------|------|

--- a/src/actions/api.ts
+++ b/src/actions/api.ts
@@ -4,6 +4,7 @@
 
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/authOptions";
+import { getTenantId } from "@/services/api";
 import type { ApiResponse } from "@/types/api";
 
 export async function apiRequest<T = any>(
@@ -11,6 +12,7 @@ export async function apiRequest<T = any>(
   options?: RequestInit
 ): Promise<ApiResponse<T>> {
   const session = (await getServerSession(authOptions)) as any;
+  const tenantId = await getTenantId();
 
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_BASE_URL}/api${endpoint}`,
@@ -22,6 +24,7 @@ export async function apiRequest<T = any>(
         ...(session?.accessToken
           ? { Authorization: `Bearer ${session.accessToken}` }
           : {}),
+        ...(tenantId ? { "X-Tenant-ID": tenantId } : {}),
         ...(options?.headers || {}),
       },
     }

--- a/src/actions/tenants.ts
+++ b/src/actions/tenants.ts
@@ -1,0 +1,64 @@
+'use server';
+
+import { apiRequest } from './api';
+import { API_ENDPOINTS } from '@/constants/api';
+import type { Tenant, User } from '@/lib/types';
+import type { ApiResponse } from '@/types/api';
+
+export async function listTenants(params?: { limit?: number; cursor?: string; }): Promise<ApiResponse<Tenant[]>> {
+  const search = new URLSearchParams();
+  if (params?.limit) search.set('limit', String(params.limit));
+  if (params?.cursor) search.set('cursor', params.cursor);
+  const endpoint = search.toString()
+    ? `${API_ENDPOINTS.tenant.list}?${search.toString()}`
+    : API_ENDPOINTS.tenant.list;
+  return apiRequest<Tenant[]>(endpoint);
+}
+
+export async function getTenant(id: string | number): Promise<ApiResponse<Tenant>> {
+  return apiRequest<Tenant>(API_ENDPOINTS.tenant.detail(id));
+}
+
+export async function createTenant(payload: { name: string; type: string; domain: string; }): Promise<ApiResponse<Tenant>> {
+  return apiRequest<Tenant>(API_ENDPOINTS.tenant.list, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function updateTenant(id: string | number, payload: { name?: string; type?: string; domain?: string; }): Promise<ApiResponse<Tenant>> {
+  return apiRequest<Tenant>(API_ENDPOINTS.tenant.detail(id), {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function updateTenantStatus(id: string | number, payload: { status: string; }): Promise<ApiResponse<Tenant>> {
+  return apiRequest<Tenant>(API_ENDPOINTS.tenant.status(id), {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function listTenantUsers(id: string | number): Promise<ApiResponse<User[]>> {
+  return apiRequest<User[]>(API_ENDPOINTS.tenant.users(id));
+}
+
+export async function addTenantUser(id: string | number, payload: { email: string; password: string; full_name: string; role_id: number; }): Promise<ApiResponse<User>> {
+  return apiRequest<User>(API_ENDPOINTS.tenant.users(id), {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function listTenantModules(id: string | number): Promise<ApiResponse<any[]>> {
+  return apiRequest<any[]>(API_ENDPOINTS.tenant.modules(id));
+}
+
+export async function updateTenantModule(id: string | number, payload: { module_id: number; status: string; }): Promise<ApiResponse<any>> {
+  return apiRequest<any>(API_ENDPOINTS.tenant.modules(id), {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+  });
+}
+

--- a/src/app/(main)/vendor/clients/[id]/page.tsx
+++ b/src/app/(main)/vendor/clients/[id]/page.tsx
@@ -1,333 +1,180 @@
 /** @format */
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Separator } from "@/components/ui/separator";
-import {
-  ArrowLeft,
-  Mail,
-  Phone,
-  MapPin,
-  Calendar,
-  ShoppingCart,
-  DollarSign,
-  Edit,
-  Trash2,
-} from "lucide-react";
+import { redirect, revalidatePath } from "next/navigation";
 import Link from "next/link";
-import { notFound } from "next/navigation";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  getTenant,
+  updateTenant,
+  updateTenantStatus,
+  listTenantUsers,
+  addTenantUser,
+  listTenantModules,
+  updateTenantModule,
+} from "@/actions/tenants";
 
-// Mock client data - in real app, this would come from API/database
-const clients = [
-  {
-    id: "1",
-    name: "PT Maju Jaya",
-    email: "contact@majujaya.com",
-    phone: "+62 21 1234567",
-    address: "Jl. Sudirman No. 123, Jakarta Pusat, DKI Jakarta 10220",
-    joinDate: "2023-01-15",
-    totalOrders: 15,
-    totalSpent: "Rp 12,500,000",
-    status: "active",
-    contactPerson: "Budi Santoso",
-    industry: "Manufacturing",
-    notes:
-      "Klien premium dengan pembayaran selalu tepat waktu. Sering order dalam jumlah besar.",
-  },
-  {
-    id: "2",
-    name: "CV Berkah Sejahtera",
-    email: "info@berkahsejahtera.com",
-    phone: "+62 22 7654321",
-    address: "Jl. Asia Afrika No. 45, Bandung, Jawa Barat 40111",
-    joinDate: "2023-03-22",
-    totalOrders: 8,
-    totalSpent: "Rp 6,750,000",
-    status: "active",
-    contactPerson: "Siti Nurhaliza",
-    industry: "Retail",
-    notes: "Klien yang berkembang pesat, potensial untuk menjadi klien besar.",
-  },
-  {
-    id: "3",
-    name: "UD Mandiri",
-    email: "admin@udmandiri.com",
-    phone: "+62 24 9876543",
-    address: "Jl. Pemuda No. 67, Semarang, Jawa Tengah 50132",
-    joinDate: "2022-11-08",
-    totalOrders: 3,
-    totalSpent: "Rp 2,100,000",
-    status: "inactive",
-    contactPerson: "Ahmad Wijaya",
-    industry: "Wholesale",
-    notes: "Klien tidak aktif sejak 3 bulan terakhir. Perlu follow up.",
-  },
-];
-
-// Mock recent orders
-const recentOrders = [
-  {
-    id: "ORD-001",
-    date: "2024-01-15",
-    amount: "Rp 2,500,000",
-    status: "completed",
-  },
-  {
-    id: "ORD-002",
-    date: "2024-01-10",
-    amount: "Rp 1,750,000",
-    status: "completed",
-  },
-  {
-    id: "ORD-003",
-    date: "2024-01-05",
-    amount: "Rp 3,200,000",
-    status: "pending",
-  },
-  {
-    id: "ORD-004",
-    date: "2023-12-28",
-    amount: "Rp 1,900,000",
-    status: "completed",
-  },
-  {
-    id: "ORD-005",
-    date: "2023-12-20",
-    amount: "Rp 2,150,000",
-    status: "completed",
-  },
-];
-
-interface ClientDetailPageProps {
-  params: {
-    id: string;
-  };
+interface PageProps {
+  params: { id: string };
+  searchParams?: { message?: string; error?: string };
 }
 
-export default function ClientDetailPage({ params }: ClientDetailPageProps) {
-  const client = clients.find((c) => c.id === params.id);
+export default async function TenantDetailPage({ params, searchParams }: PageProps) {
+  const id = params.id;
+  const { data: tenant, success } = await getTenant(id);
+  if (!success || !tenant) redirect("/tenant-not-found");
 
-  if (!client) {
-    notFound();
+  const usersRes = await listTenantUsers(id);
+  const modulesRes = await listTenantModules(id);
+
+  async function updateTenantAction(formData: FormData) {
+    "use server";
+    const res = await updateTenant(id, {
+      name: String(formData.get("name")),
+      type: String(formData.get("type")),
+      domain: String(formData.get("domain")),
+    });
+    revalidatePath(`/vendor/clients/${id}`);
+    if (!res.success) {
+      redirect(`/vendor/clients/${id}?error=${encodeURIComponent(res.message)}`);
+    }
+    redirect(`/vendor/clients/${id}?message=${encodeURIComponent(res.message)}`);
+  }
+
+  async function updateStatusAction(formData: FormData) {
+    "use server";
+    const status = formData.get("status") === "on" ? "active" : "inactive";
+    const res = await updateTenantStatus(id, { status });
+    revalidatePath(`/vendor/clients/${id}`);
+    const target = res.success
+      ? `/vendor/clients/${id}?message=${encodeURIComponent(res.message)}`
+      : `/vendor/clients/${id}?error=${encodeURIComponent(res.message)}`;
+    redirect(target);
+  }
+
+  async function addUserAction(formData: FormData) {
+    "use server";
+    const res = await addTenantUser(id, {
+      email: String(formData.get("email")),
+      password: String(formData.get("password")),
+      full_name: String(formData.get("full_name")),
+      role_id: Number(formData.get("role_id")),
+    });
+    revalidatePath(`/vendor/clients/${id}`);
+    const target = res.success
+      ? `/vendor/clients/${id}?message=${encodeURIComponent(res.message)}`
+      : `/vendor/clients/${id}?error=${encodeURIComponent(res.message)}`;
+    redirect(target);
+  }
+
+  async function toggleModuleAction(formData: FormData) {
+    "use server";
+    const res = await updateTenantModule(id, {
+      module_id: Number(formData.get("module_id")),
+      status: String(formData.get("status")),
+    });
+    revalidatePath(`/vendor/clients/${id}`);
+    const target = res.success
+      ? `/vendor/clients/${id}?message=${encodeURIComponent(res.message)}`
+      : `/vendor/clients/${id}?error=${encodeURIComponent(res.message)}`;
+    redirect(target);
   }
 
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <Link href="/vendor/clients">
-            <Button variant="outline" size="sm">
-              <ArrowLeft className="h-4 w-4 mr-2" />
-              Back to Clients
-            </Button>
-          </Link>
-          <div>
-            <h2 className="text-2xl font-bold">{client.name}</h2>
-            <p className="text-muted-foreground">
-              Client Details & Order History
-            </p>
-          </div>
+    <div className="space-y-8">
+      <Link href="/vendor/clients">← Back</Link>
+      {searchParams?.message && (
+        <p className="text-green-600">{searchParams.message}</p>
+      )}
+      {searchParams?.error && (
+        <p className="text-red-600">{searchParams.error}</p>
+      )}
+      <form action={updateTenantAction} className="space-y-4">
+        <div>
+          <Label htmlFor="name">Name</Label>
+          <Input id="name" name="name" defaultValue={tenant.name} />
         </div>
-        <div className="flex gap-2">
-          <Button variant="outline">
-            <Edit className="h-4 w-4 mr-2" />
-            Edit Client
-          </Button>
-          <Button variant="destructive">
-            <Trash2 className="h-4 w-4 mr-2" />
-            Delete
-          </Button>
+        <div>
+          <Label htmlFor="type">Type</Label>
+          <Input id="type" name="type" defaultValue={tenant.type} />
         </div>
-      </div>
-
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Client Information */}
-        <div className="lg:col-span-2 space-y-6">
-          {/* Basic Info */}
-          <Card>
-            <CardHeader>
-              <div className="flex items-center justify-between">
-                <CardTitle>Client Information</CardTitle>
-                <Badge
-                  variant={client.status === "active" ? "default" : "secondary"}
-                >
-                  {client.status}
-                </Badge>
-              </div>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div className="space-y-3">
-                  <div className="flex items-center gap-2">
-                    <Mail className="h-4 w-4 text-muted-foreground" />
-                    <div>
-                      <p className="text-sm text-muted-foreground">Email</p>
-                      <p className="font-medium">{client.email}</p>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Phone className="h-4 w-4 text-muted-foreground" />
-                    <div>
-                      <p className="text-sm text-muted-foreground">Phone</p>
-                      <p className="font-medium">{client.phone}</p>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Calendar className="h-4 w-4 text-muted-foreground" />
-                    <div>
-                      <p className="text-sm text-muted-foreground">Join Date</p>
-                      <p className="font-medium">
-                        {new Date(client.joinDate).toLocaleDateString("id-ID")}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-                <div className="space-y-3">
-                  <div>
-                    <p className="text-sm text-muted-foreground">
-                      Contact Person
-                    </p>
-                    <p className="font-medium">{client.contactPerson}</p>
-                  </div>
-                  <div>
-                    <p className="text-sm text-muted-foreground">Industry</p>
-                    <p className="font-medium">{client.industry}</p>
-                  </div>
-                </div>
-              </div>
-
-              <Separator />
-
-              <div className="flex items-start gap-2">
-                <MapPin className="h-4 w-4 text-muted-foreground mt-1" />
-                <div>
-                  <p className="text-sm text-muted-foreground">Address</p>
-                  <p className="font-medium">{client.address}</p>
-                </div>
-              </div>
-
-              {client.notes && (
-                <>
-                  <Separator />
-                  <div>
-                    <p className="text-sm text-muted-foreground">Notes</p>
-                    <p className="font-medium">{client.notes}</p>
-                  </div>
-                </>
-              )}
-            </CardContent>
-          </Card>
-
-          {/* Recent Orders */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Recent Orders</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-3">
-                {recentOrders.map((order) => (
-                  <div
-                    key={order.id}
-                    className="flex items-center justify-between p-3 border rounded-lg"
-                  >
-                    <div className="flex items-center gap-3">
-                      <ShoppingCart className="h-4 w-4 text-muted-foreground" />
-                      <div>
-                        <p className="font-medium">{order.id}</p>
-                        <p className="text-sm text-muted-foreground">
-                          {new Date(order.date).toLocaleDateString("id-ID")}
-                        </p>
-                      </div>
-                    </div>
-                    <div className="text-right">
-                      <p className="font-medium">{order.amount}</p>
-                      <Badge
-                        variant={
-                          order.status === "completed" ? "default" : "secondary"
-                        }
-                        className="text-xs"
-                      >
-                        {order.status}
-                      </Badge>
-                    </div>
-                  </div>
-                ))}
-              </div>
-              <Button variant="outline" className="w-full mt-4 bg-transparent">
-                View All Orders
-              </Button>
-            </CardContent>
-          </Card>
+        <div>
+          <Label htmlFor="domain">Domain</Label>
+          <Input id="domain" name="domain" defaultValue={tenant.domain} />
         </div>
+        <Button type="submit">Save</Button>
+      </form>
 
-        {/* Statistics */}
-        <div className="space-y-6">
-          <Card>
-            <CardHeader>
-              <CardTitle>Statistics</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="flex items-center gap-3">
-                <div className="p-2 bg-blue-100 rounded-lg">
-                  <ShoppingCart className="h-4 w-4 text-blue-600" />
-                </div>
-                <div>
-                  <p className="text-sm text-muted-foreground">Total Orders</p>
-                  <p className="text-2xl font-bold">{client.totalOrders}</p>
-                </div>
-              </div>
+      <form action={updateStatusAction} className="flex items-center gap-2">
+        <Switch name="status" defaultChecked={tenant.status === "active"} />
+        <Button type="submit">Update Status</Button>
+      </form>
 
-              <div className="flex items-center gap-3">
-                <div className="p-2 bg-green-100 rounded-lg">
-                  <DollarSign className="h-4 w-4 text-green-600" />
-                </div>
-                <div>
-                  <p className="text-sm text-muted-foreground">Total Spent</p>
-                  <p className="text-2xl font-bold">{client.totalSpent}</p>
-                </div>
-              </div>
+      <section className="space-y-4">
+        <h3 className="text-xl font-semibold">Users</h3>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Email</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {usersRes.data?.map((u) => (
+              <TableRow key={u.id}>
+                <TableCell>{u.name}</TableCell>
+                <TableCell>{u.email}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+        <form action={addUserAction} className="space-y-2">
+          <Input name="email" placeholder="email" />
+          <Input name="password" placeholder="password" type="password" />
+          <Input name="full_name" placeholder="full name" />
+          <Input name="role_id" placeholder="role id" />
+          <Button type="submit">Add User</Button>
+        </form>
+      </section>
 
-              <div className="flex items-center gap-3">
-                <div className="p-2 bg-purple-100 rounded-lg">
-                  <Calendar className="h-4 w-4 text-purple-600" />
-                </div>
-                <div>
-                  <p className="text-sm text-muted-foreground">
-                    Customer Since
-                  </p>
-                  <p className="text-lg font-semibold">
-                    {new Date(client.joinDate).toLocaleDateString("id-ID", {
-                      year: "numeric",
-                      month: "long",
-                    })}
-                  </p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Quick Actions */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Quick Actions</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2">
-              <Button className="w-full">Create New Order</Button>
-              <Button variant="outline" className="w-full bg-transparent">
-                Send Invoice
-              </Button>
-              <Button variant="outline" className="w-full bg-transparent">
-                Send Message
-              </Button>
-              <Button variant="outline" className="w-full bg-transparent">
-                Schedule Meeting
-              </Button>
-            </CardContent>
-          </Card>
-        </div>
-      </div>
+      <section className="space-y-4">
+        <h3 className="text-xl font-semibold">Modules</h3>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {modulesRes.data?.map((m) => (
+              <TableRow key={m.id}>
+                <TableCell>{m.name}</TableCell>
+                <TableCell>
+                  <form action={toggleModuleAction}>
+                    <input type="hidden" name="module_id" value={m.id} />
+                    <select name="status" defaultValue={m.status}>
+                      <option value="active">active</option>
+                      <option value="inactive">inactive</option>
+                    </select>
+                    <Button type="submit" size="sm" className="ml-2">Save</Button>
+                  </form>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </section>
     </div>
   );
 }

--- a/src/app/(main)/vendor/clients/page.tsx
+++ b/src/app/(main)/vendor/clients/page.tsx
@@ -1,112 +1,52 @@
 /** @format */
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import Link from "next/link";
+import { listTenants } from "@/actions/tenants";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Input } from "@/components/ui/input";
-import { Plus, Search, Mail, Phone } from "lucide-react";
 
-const clients = [
-  {
-    id: "1",
-    name: "PT Maju Jaya",
-    email: "contact@majujaya.com",
-    phone: "+62 21 1234567",
-    totalOrders: 15,
-    totalSpent: "Rp 12,500,000",
-    status: "active",
-  },
-  {
-    id: "2",
-    name: "CV Berkah Sejahtera",
-    email: "info@berkahsejahtera.com",
-    phone: "+62 22 7654321",
-    totalOrders: 8,
-    totalSpent: "Rp 6,750,000",
-    status: "active",
-  },
-  {
-    id: "3",
-    name: "UD Mandiri",
-    email: "admin@udmandiri.com",
-    phone: "+62 24 9876543",
-    totalOrders: 3,
-    totalSpent: "Rp 2,100,000",
-    status: "inactive",
-  },
-];
+export default async function TenantsPage() {
+  const { data: tenants } = await listTenants();
 
-export default function ClientsPage() {
   return (
     <div className="space-y-6">
-      {/* Header */}
       <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-2xl font-bold">Clients</h2>
-          <p className="text-muted-foreground">
-            Manage your client relationships
-          </p>
-        </div>
-        <Button>
-          <Plus className="h-4 w-4 mr-2" />
-          Add Client
-        </Button>
+        <h2 className="text-2xl font-bold">Tenants</h2>
+        <Link href="/vendor/clients/create">
+          <Button>Create</Button>
+        </Link>
       </div>
-
-      {/* Search */}
-      <Card>
-        <CardContent className="pt-6">
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-            <Input placeholder="Search clients..." className="pl-10" />
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Clients Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {clients.map((client) => (
-          <Card key={client.id}>
-            <CardHeader>
-              <div className="flex items-center justify-between">
-                <CardTitle className="text-lg">{client.name}</CardTitle>
-                <Badge
-                  variant={client.status === "active" ? "default" : "secondary"}
-                >
-                  {client.status}
-                </Badge>
-              </div>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <div className="flex items-center gap-2 text-sm">
-                  <Mail className="h-4 w-4 text-muted-foreground" />
-                  <span>{client.email}</span>
-                </div>
-                <div className="flex items-center gap-2 text-sm">
-                  <Phone className="h-4 w-4 text-muted-foreground" />
-                  <span>{client.phone}</span>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-2 gap-4 pt-4 border-t">
-                <div>
-                  <p className="text-sm text-muted-foreground">Total Orders</p>
-                  <p className="font-semibold">{client.totalOrders}</p>
-                </div>
-                <div>
-                  <p className="text-sm text-muted-foreground">Total Spent</p>
-                  <p className="font-semibold">{client.totalSpent}</p>
-                </div>
-              </div>
-
-              <Button variant="outline" className="w-full bg-transparent">
-                View Details
-              </Button>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>Type</TableHead>
+            <TableHead>Domain</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead></TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {tenants?.map((t) => (
+            <TableRow key={t.id}>
+              <TableCell>{t.name}</TableCell>
+              <TableCell>{t.type}</TableCell>
+              <TableCell>{t.domain}</TableCell>
+              <TableCell>{t.status}</TableCell>
+              <TableCell>
+                <Link href={`/vendor/clients/${t.id}`}>View</Link>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
     </div>
   );
 }

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -3,6 +3,11 @@
 export const API_ENDPOINTS = {
   tenant: {
     byDomain: "/tenant/by-domain",
+    list: "/tenants",
+    detail: (id: string | number) => `/tenants/${id}`,
+    status: (id: string | number) => `/tenants/${id}/status`,
+    users: (id: string | number) => `/tenants/${id}/users`,
+    modules: (id: string | number) => `/tenants/${id}/modules`,
   },
   auth: {
     login: "/auth/login",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -16,3 +16,11 @@ export interface DashboardStats {
   change?: string;
   trend?: "up" | "down" | "neutral";
 }
+
+export interface Tenant {
+  id: string | number;
+  name: string;
+  type: string;
+  domain: string;
+  status: string;
+}


### PR DESCRIPTION
## Summary
- extend API constants with tenant endpoints
- add tenant server actions and integrate tenant pages
- document tenant management UI

## Testing
- `npm test` (fails: expected redirect to dashboard)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a752d592488322a678b90a65114bf0