### PR TITLE
Handle API error responses

### DIFF
--- a/src/__tests__/api.spec.ts
+++ b/src/__tests__/api.spec.ts
@@ -1,0 +1,42 @@
+/** @format */
+
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { apiFetch } from "@/actions/api";
+
+vi.mock("next-auth", () => ({
+  getServerSession: vi.fn().mockResolvedValue({ user: {} }),
+}));
+
+const originalFetch = global.fetch;
+
+describe("apiFetch", () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = "http://example.com";
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it.each([
+    [404, "Not Found"],
+    [500, "Server Error"],
+  ])("throws error for status %s", async (status, message) => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({
+        ok: false,
+        status,
+        json: async () => ({ message }),
+      }) as any;
+
+    const promise = apiFetch("/test");
+    await expect(promise).rejects.toThrow(message);
+    await promise.catch((err) => {
+      expect((err as any).status).toBe(status);
+    });
+  });
+});
+

--- a/src/__tests__/auth.spec.tsx
+++ b/src/__tests__/auth.spec.tsx
@@ -45,7 +45,7 @@ describe("auth flow", () => {
 
   it("redirects to dashboard based on role after successful login", async () => {
     (login as any).mockResolvedValue(loginFixture);
-    (getSession as any).mockResolvedValue({ user: { role: "umkm" } });
+    (getSession as any).mockResolvedValue({ user: { jenis_tenant: "umkm" } });
 
     const { getByLabelText, getByRole } = render(
       <LanguageProvider>

--- a/src/actions/api.ts
+++ b/src/actions/api.ts
@@ -28,6 +28,13 @@ export async function apiRequest<T = any>(
   });
 
   const json = (await res.json().catch(() => null)) as ApiResponse<T>;
+
+  if (!res.ok) {
+    const error: any = new Error(json?.message || res.statusText);
+    error.status = res.status;
+    throw error;
+  }
+
   return json;
 }
 
@@ -36,5 +43,8 @@ export async function apiFetch<T = any>(
   options?: RequestInit
 ): Promise<T> {
   const json = await apiRequest<T>(endpoint, options);
-  return json?.data as T;
+  if (!json?.success) {
+    throw new Error(json?.message || "API request failed");
+  }
+  return json.data as T;
 }


### PR DESCRIPTION
## Summary
- throw detailed errors from `apiRequest` when the HTTP response is not OK
- propagate API failures in `apiFetch` and ensure success flag
- add tests verifying 4xx/5xx requests reject with status

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a80db617c883228fc4bd0719f7c344