### PR TITLE
feat(auth): implement refresh token flow

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,10 +1,6 @@
 /** @format */
 
-import {
-  getAccessToken,
-  refreshToken as refreshAccessToken,
-  logout,
-} from "./auth";
+import { getAccessToken, refreshToken, logout } from "./auth";
 
 export async function getTenantId(): Promise<string | null> {
   if (typeof window !== "undefined") {
@@ -53,7 +49,7 @@ async function request(path: string, options: RequestInit = {}) {
   let res = await fetch(`${BASE_URL}${path}`, { ...options, headers, body });
 
   if (res.status === 401) {
-    const newToken = await refreshAccessToken();
+    const newToken = await refreshToken();
     if (newToken) {
       accessToken = newToken;
       headers.set("Authorization", `Bearer ${accessToken}`);


### PR DESCRIPTION
## Summary
- implement refresh token request and cookie update
- use new refreshToken in API service
- add tests for refresh token success and failure

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68a80dad86588322bcf148e7d1c51b40