### PR TITLE
Validate environment variables at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,13 @@ Dashboard menyediakan rute awal untuk modul-modul berikut:
    ```bash
    npm install
    ```
-2. Siapkan file `.env.local` dengan variabel:
+2. Siapkan file `.env.local` dengan variabel wajib berikut:
    ```bash
    NEXT_PUBLIC_API_URL=http://localhost:8080
+   NEXT_PUBLIC_BASE_URL=http://localhost:3000
+   NEXTAUTH_URL=http://localhost:3000
+   NEXTAUTH_SECRET=your_secret_key
+   NEXTAUTH_URL_INTERNAL=http://localhost:3000
    ```
 3. Jalankan server pengembangan:
    ```bash

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,14 +1,15 @@
 /** @format */
 
 import type { NextConfig } from "next";
+import { env } from "./src/lib/env";
 
 const nextConfig: NextConfig = {
   env: {
-    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
-    NEXT_PUBLIC_BASE_URL: process.env.NEXT_PUBLIC_BASE_URL,
-    NEXTAUTH_URL: process.env.NEXTAUTH_URL,
-    NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
-    NEXTAUTH_URL_INTERNAL: process.env.NEXTAUTH_URL_INTERNAL,
+    NEXT_PUBLIC_API_URL: env.NEXT_PUBLIC_API_URL,
+    NEXT_PUBLIC_BASE_URL: env.NEXT_PUBLIC_BASE_URL,
+    NEXTAUTH_URL: env.NEXTAUTH_URL,
+    NEXTAUTH_SECRET: env.NEXTAUTH_SECRET,
+    NEXTAUTH_URL_INTERNAL: env.NEXTAUTH_URL_INTERNAL,
   },
 };
 

--- a/src/__tests__/api.spec.ts
+++ b/src/__tests__/api.spec.ts
@@ -2,7 +2,8 @@
 
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { apiFetch } from "@/actions/api";
+
+let apiFetch: typeof import("@/actions/api").apiFetch;
 
 vi.mock("next-auth", () => ({
   getServerSession: vi.fn().mockResolvedValue({ user: {} }),
@@ -11,8 +12,14 @@ vi.mock("next-auth", () => ({
 const originalFetch = global.fetch;
 
 describe("apiFetch", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     process.env.NEXT_PUBLIC_API_URL = "http://example.com";
+    process.env.NEXT_PUBLIC_BASE_URL = "http://localhost:3000";
+    process.env.NEXTAUTH_URL = "http://localhost:3000";
+    process.env.NEXTAUTH_SECRET = "secret";
+    process.env.NEXTAUTH_URL_INTERNAL = "http://localhost:3000";
+    vi.resetModules();
+    ({ apiFetch } = await import("@/actions/api"));
   });
 
   afterEach(() => {

--- a/src/__tests__/auth.spec.tsx
+++ b/src/__tests__/auth.spec.tsx
@@ -1,7 +1,9 @@
 /** @format */
 
 // @vitest-environment jsdom
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import React from "react";
+import { render, fireEvent, waitFor } from "@testing-library/react";
 
 const push = vi.fn();
 
@@ -22,13 +24,28 @@ vi.mock("@/services/auth", async () => {
   };
 });
 
-import { render, fireEvent, waitFor } from "@testing-library/react";
-import { LoginForm } from "@/components/shared/login-form";
-import { LanguageProvider } from "@/contexts/language-context";
-import { refreshAccessToken } from "@/lib/authOptions";
-import { logout, login, refreshToken } from "@/services/auth";
-import { getSession, signOut } from "next-auth/react";
-import React from "react";
+let LoginForm: typeof import("@/components/shared/login-form").LoginForm;
+let LanguageProvider: typeof import("@/contexts/language-context").LanguageProvider;
+let refreshAccessToken: typeof import("@/lib/authOptions").refreshAccessToken;
+let logout: typeof import("@/services/auth").logout;
+let login: typeof import("@/services/auth").login;
+let refreshToken: typeof import("@/services/auth").refreshToken;
+let getSession: typeof import("next-auth/react").getSession;
+let signOut: typeof import("next-auth/react").signOut;
+
+beforeEach(async () => {
+  process.env.NEXT_PUBLIC_API_URL = "http://example.com";
+  process.env.NEXT_PUBLIC_BASE_URL = "http://localhost:3000";
+  process.env.NEXTAUTH_URL = "http://localhost:3000";
+  process.env.NEXTAUTH_SECRET = "secret";
+  process.env.NEXTAUTH_URL_INTERNAL = "http://localhost:3000";
+  vi.resetModules();
+  LoginForm = (await import("@/components/shared/login-form")).LoginForm;
+  LanguageProvider = (await import("@/contexts/language-context")).LanguageProvider;
+  refreshAccessToken = (await import("@/lib/authOptions")).refreshAccessToken;
+  ({ logout, login, refreshToken } = await import("@/services/auth"));
+  ({ getSession, signOut } = await import("next-auth/react"));
+});
 
 // fixtures based on docs/frontend/auth_flow.md
 const loginFixture = {

--- a/src/actions/api.ts
+++ b/src/actions/api.ts
@@ -5,6 +5,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/authOptions";
 import type { ApiResponse } from "@/types/api";
 import { UserSession } from "@/types/session";
+import { env } from "@/lib/env";
 
 export async function apiRequest<T = any>(
   endpoint: string,
@@ -12,7 +13,7 @@ export async function apiRequest<T = any>(
 ): Promise<ApiResponse<T>> {
   const session = (await getServerSession(authOptions)) as UserSession;
 
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api${endpoint}`, {
+  const res = await fetch(`${env.NEXT_PUBLIC_API_URL}/api${endpoint}`, {
     cache: "no-store",
     ...options,
     headers: {

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -2,11 +2,12 @@
 import { AuthOptions } from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 import { getTenantId } from "@/services/api";
+import { env } from "./env";
 
 export async function refreshAccessToken(token: any) {
   try {
     const res = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/api/auth/refresh`,
+      `${env.NEXT_PUBLIC_API_URL}/api/auth/refresh`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -47,7 +48,7 @@ export const authOptions: AuthOptions = {
 
         try {
           const res = await fetch(
-            `${process.env.NEXT_PUBLIC_API_URL}/api/auth/login`,
+            `${env.NEXT_PUBLIC_API_URL}/api/auth/login`,
             {
               method: "POST",
               headers: {
@@ -120,5 +121,5 @@ export const authOptions: AuthOptions = {
     signOut: "/auth/login",
   },
 
-  secret: process.env.NEXTAUTH_SECRET,
+  secret: env.NEXTAUTH_SECRET,
 };

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,13 @@
+/** @format */
+
+import { z } from "zod";
+
+const envSchema = z.object({
+  NEXT_PUBLIC_API_URL: z.string().url(),
+  NEXT_PUBLIC_BASE_URL: z.string().url(),
+  NEXTAUTH_URL: z.string().url(),
+  NEXTAUTH_SECRET: z.string().min(1),
+  NEXTAUTH_URL_INTERNAL: z.string().url(),
+});
+
+export const env = envSchema.parse(process.env);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,12 +3,13 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { getToken } from "next-auth/jwt";
+import { env } from "@/lib/env";
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const host = request.headers.get("host") ?? "";
 
-  const apiBase = process.env.NEXT_PUBLIC_API_URL ?? "";
+  const apiBase = env.NEXT_PUBLIC_API_URL;
 
   let tenantId = request.cookies.get("tenantId")?.value;
 
@@ -56,7 +57,7 @@ export async function middleware(request: NextRequest) {
   // cek token NextAuth
   const token = await getToken({
     req: request,
-    secret: process.env.NEXTAUTH_SECRET,
+    secret: env.NEXTAUTH_SECRET,
   });
   const userRole = (token as any)?.jenis_tenant;
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,6 +1,7 @@
 /** @format */
 
 import { getAccessToken, refreshToken, logout } from "./auth";
+import { env } from "@/lib/env";
 
 export async function getTenantId(): Promise<string | null> {
   if (typeof window !== "undefined") {
@@ -15,7 +16,7 @@ export async function getTenantId(): Promise<string | null> {
   }
 }
 
-const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+const BASE_URL = env.NEXT_PUBLIC_API_URL;
 
 export class ApiError extends Error {
   status: number;

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,8 +1,9 @@
 /** @format */
 
 import { getSession, signIn, signOut } from "next-auth/react";
+import { env } from "@/lib/env";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+const API_URL = env.NEXT_PUBLIC_API_URL;
 
 export async function login(email: string, password: string) {
   const res = await signIn("credentials", {


### PR DESCRIPTION
## Summary
- add `env` module using zod to validate required environment variables
- enforce env validation across config, auth, middleware, and services
- document required env variables in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a811e3aac08322b0c6004baa14f79e