### PR TITLE
test: cover middleware and shared components

### DIFF
--- a/src/__tests__/api-service.spec.ts
+++ b/src/__tests__/api-service.spec.ts
@@ -1,0 +1,99 @@
+/** @format */
+
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { api, ApiError, getTenantId } from "@/services/api";
+import { getAccessToken, refreshToken, logout } from "@/services/auth";
+
+vi.mock("@/services/auth", () => ({
+  getAccessToken: vi.fn(),
+  refreshToken: vi.fn(),
+  logout: vi.fn(),
+}));
+
+const originalFetch = global.fetch;
+
+describe("api service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_API_URL = "http://api.local";
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("retries with new token on 401", async () => {
+    (getAccessToken as any).mockResolvedValue("old");
+    (refreshToken as any).mockResolvedValue("new");
+
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        status: 401,
+        ok: false,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({ message: "unauthorized" }),
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({ success: true }),
+      }) as any;
+
+    const result = await api.get("/test");
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    const secondCall = (global.fetch as any).mock.calls[1];
+    expect(secondCall[1].headers.get("Authorization")).toBe("Bearer new");
+    expect(result).toEqual({ success: true });
+  });
+
+  it("calls logout when refreshToken fails", async () => {
+    (getAccessToken as any).mockResolvedValue("old");
+    (refreshToken as any).mockResolvedValue(null);
+
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({
+        status: 401,
+        ok: false,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({ error: "unauthorized" }),
+      }) as any;
+
+    const promise = api.get("/test");
+    await expect(promise).rejects.toBeInstanceOf(ApiError);
+    await promise.catch((err) => {
+      expect((err as any).status).toBe(401);
+    });
+    expect(logout).toHaveBeenCalled();
+  });
+
+  it("throws ApiError for non-ok response", async () => {
+    (getAccessToken as any).mockResolvedValue(null);
+
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({
+        status: 500,
+        ok: false,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({ message: "boom" }),
+      }) as any;
+
+    const promise = api.get("/err");
+    await expect(promise).rejects.toBeInstanceOf(ApiError);
+    await promise.catch((err) => {
+      expect((err as any).status).toBe(500);
+      expect((err as any).data).toEqual({ message: "boom" });
+    });
+  });
+
+  it("getTenantId reads from cookie", async () => {
+    document.cookie = "tenantId=abc";
+    const id = await getTenantId();
+    expect(id).toBe("abc");
+  });
+});
+

--- a/src/__tests__/language-toggle.spec.tsx
+++ b/src/__tests__/language-toggle.spec.tsx
@@ -1,0 +1,22 @@
+/** @format */
+
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { LanguageProvider } from "@/contexts/language-context";
+import { LanguageToggle } from "@/components/shared/language-toggle";
+
+describe("LanguageToggle", () => {
+  it("toggles language on click", () => {
+    const { getByRole } = render(
+      <LanguageProvider>
+        <LanguageToggle />
+      </LanguageProvider>
+    );
+    const button = getByRole("button");
+    expect(button.textContent).toBe("ID");
+    fireEvent.click(button);
+    expect(button.textContent).toBe("EN");
+  });
+});
+

--- a/src/__tests__/middleware.spec.ts
+++ b/src/__tests__/middleware.spec.ts
@@ -1,0 +1,87 @@
+/** @format */
+
+// @vitest-environment node
+vi.mock("next-auth/jwt", () => ({
+  getToken: vi.fn(),
+}));
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { middleware } from "@/middleware";
+import { getToken } from "next-auth/jwt";
+
+function createRequest(
+  path: string,
+  opts: { tenantId?: string; host?: string } = {}
+) {
+  const url = `http://${opts.host ?? "example.com"}${path}`;
+  const cookies = {
+    get: (name: string) =>
+      name === "tenantId" && opts.tenantId
+        ? { value: opts.tenantId }
+        : undefined,
+  };
+  return {
+    nextUrl: new URL(url),
+    headers: new Headers({ host: opts.host ?? "example.com" }),
+    cookies,
+    url,
+  } as any;
+}
+
+const originalFetch = global.fetch;
+
+describe("middleware", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_API_URL = "http://api.local";
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("injects tenant id from cookie", async () => {
+    (getToken as any).mockResolvedValue(null);
+    const req = createRequest("/dashboard", { tenantId: "123" });
+    const res = await middleware(req);
+    expect(res.headers.get("X-Tenant-ID")).toBe("123");
+    expect(res.cookies.get("tenantId")?.value).toBe("123");
+  });
+
+  it("looks up tenant by domain when cookie missing", async () => {
+    (getToken as any).mockResolvedValue(null);
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: { tenant_id: 42 } }),
+      }) as any;
+    const req = createRequest("/dashboard", { host: "foo.com" });
+    const res = await middleware(req);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://api.local/api/tenant/by-domain?domain=foo.com",
+      { headers: { "Content-Type": "application/json" } }
+    );
+    expect(res.headers.get("X-Tenant-ID")).toBe("42");
+    expect(res.cookies.get("tenantId")?.value).toBe("42");
+  });
+
+  it("redirects to tenant-not-found when lookup fails", async () => {
+    (getToken as any).mockResolvedValue(null);
+    global.fetch = vi.fn().mockResolvedValue({ ok: false }) as any;
+    const req = createRequest("/dashboard", { host: "foo.com" });
+    const res = await middleware(req);
+    expect(res.headers.get("location")).toContain("/tenant-not-found");
+  });
+
+  it("redirects to login when accessing protected route without token", async () => {
+    (getToken as any).mockResolvedValue(null);
+    const req = createRequest("/umkm/dashboard", { tenantId: "1" });
+    const res = await middleware(req);
+    expect(res.headers.get("location")).toBe(
+      "http://example.com/login?redirect=%2Fumkm%2Fdashboard"
+    );
+  });
+});
+

--- a/src/__tests__/theme-toggle.spec.tsx
+++ b/src/__tests__/theme-toggle.spec.tsx
@@ -1,0 +1,37 @@
+/** @format */
+
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, cleanup } from "@testing-library/react";
+import { ThemeToggle } from "@/components/shared/theme-toggle";
+
+const setTheme = vi.fn();
+let theme = "light";
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ theme, setTheme }),
+}));
+
+describe("ThemeToggle", () => {
+  beforeEach(() => {
+    setTheme.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("switches to dark when currently light", () => {
+    theme = "light";
+    const { getByRole } = render(<ThemeToggle />);
+    fireEvent.click(getByRole("switch"));
+    expect(setTheme).toHaveBeenCalledWith("dark");
+  });
+
+  it("switches to light when currently dark", () => {
+    theme = "dark";
+    const { getByRole } = render(<ThemeToggle />);
+    fireEvent.click(getByRole("switch"));
+    expect(setTheme).toHaveBeenCalledWith("light");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add comprehensive middleware tests for tenant detection and auth redirects
- ensure API service handles token refresh, logout and errors
- verify language and theme toggles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a811e370cc83228a04efd161073786