### PR TITLE
feat: add typed actions

### DIFF
--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -4,6 +4,8 @@
 
 import { apiFetch } from "./api";
 import { API_ENDPOINTS } from "@/constants/api";
+import { ensureSuccess } from "@/lib/api";
+import { login as loginService, logout as logoutService } from "@/services/api";
 
 export async function login(payload: { email: string; password: string }) {
   return apiFetch(API_ENDPOINTS.auth.login, {
@@ -25,3 +27,17 @@ export async function logout(payload: { refresh_token: string }) {
     body: JSON.stringify(payload),
   });
 }
+
+export async function loginAction(payload: { email: string; password: string }) {
+  const res = await loginService(payload);
+  return ensureSuccess(res);
+}
+
+export type LoginActionResult = Awaited<ReturnType<typeof loginAction>>;
+
+export async function logoutAction() {
+  const res = await logoutService();
+  return ensureSuccess(res);
+}
+
+export type LogoutActionResult = Awaited<ReturnType<typeof logoutAction>>;

--- a/src/actions/billing.ts
+++ b/src/actions/billing.ts
@@ -1,0 +1,36 @@
+/** @format */
+
+"use server";
+
+import { ensureSuccess } from "@/lib/api";
+import {
+  listVendorInvoices,
+  listClientInvoices,
+  createPayment,
+} from "@/services/api";
+
+export async function listInvoicesAction(
+  type: "vendor" | "client" = "client"
+) {
+  const res =
+    type === "vendor"
+      ? await listVendorInvoices()
+      : await listClientInvoices();
+  return ensureSuccess(res);
+}
+
+export type ListInvoicesActionResult = Awaited<
+  ReturnType<typeof listInvoicesAction>
+>;
+
+export async function createPaymentAction(
+  invoiceId: string | number,
+  payload: any
+) {
+  const res = await createPayment(invoiceId, payload);
+  return ensureSuccess(res);
+}
+
+export type CreatePaymentActionResult = Awaited<
+  ReturnType<typeof createPaymentAction>
+>;

--- a/src/actions/role.ts
+++ b/src/actions/role.ts
@@ -1,0 +1,27 @@
+/** @format */
+
+"use server";
+
+import { ensureSuccess } from "@/lib/api";
+import { listRoles, assignRole } from "@/services/api";
+
+export async function listRolesAction() {
+  const res = await listRoles();
+  return ensureSuccess(res);
+}
+
+export type ListRolesActionResult = Awaited<
+  ReturnType<typeof listRolesAction>
+>;
+
+export async function assignRoleAction(
+  userId: string | number,
+  payload: { role_id: string | number; tenant_id?: string | number }
+) {
+  const res = await assignRole(userId, payload);
+  return ensureSuccess(res);
+}
+
+export type AssignRoleActionResult = Awaited<
+  ReturnType<typeof assignRoleAction>
+>;

--- a/src/actions/tenants.ts
+++ b/src/actions/tenants.ts
@@ -6,6 +6,11 @@ import { apiRequest } from "./api";
 import { API_ENDPOINTS } from "@/constants/api";
 import type { Tenant, User } from "@/lib/types";
 import type { ApiResponse } from "@/types/api";
+import { ensureSuccess } from "@/lib/api";
+import {
+  listTenants as listTenantsService,
+  getTenantByDomain,
+} from "@/services/api";
 
 export async function listTenants(params?: {
   limit?: number;
@@ -93,3 +98,23 @@ export async function updateTenantModule(
     body: JSON.stringify(payload),
   });
 }
+
+export async function listTenantsAction(
+  params?: Record<string, string | number>
+) {
+  const res = await listTenantsService(params);
+  return ensureSuccess(res);
+}
+
+export type ListTenantsActionResult = Awaited<
+  ReturnType<typeof listTenantsAction>
+>;
+
+export async function getTenantByDomainAction(domain: string) {
+  const res = await getTenantByDomain(domain);
+  return ensureSuccess(res);
+}
+
+export type GetTenantByDomainActionResult = Awaited<
+  ReturnType<typeof getTenantByDomainAction>
+>;

--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -6,6 +6,12 @@ import { apiRequest } from "./api";
 import { API_ENDPOINTS } from "@/constants/api";
 import type { User } from "@/lib/types";
 import type { ApiResponse } from "@/types/api";
+import { ensureSuccess } from "@/lib/api";
+import {
+  listUsers as listUsersService,
+  createUser as createUserService,
+  resetPassword,
+} from "@/services/api";
 
 export async function listUsers(params?: {
   limit?: number;
@@ -35,3 +41,32 @@ export async function createUser(payload: {
     body: JSON.stringify(payload),
   });
 }
+
+export async function listUsersAction(
+  params?: Record<string, string | number>
+) {
+  const res = await listUsersService(params);
+  return ensureSuccess(res);
+}
+
+export type ListUsersActionResult = Awaited<
+  ReturnType<typeof listUsersAction>
+>;
+
+export async function createUserAction(payload: Partial<User>) {
+  const res = await createUserService(payload);
+  return ensureSuccess(res);
+}
+
+export type CreateUserActionResult = Awaited<
+  ReturnType<typeof createUserAction>
+>;
+
+export async function resetPasswordAction(payload: { email: string }) {
+  const res = await resetPassword(payload);
+  return ensureSuccess(res);
+}
+
+export type ResetPasswordActionResult = Awaited<
+  ReturnType<typeof resetPasswordAction>
+>;


### PR DESCRIPTION
## Summary
- add role and billing actions
- expose typed auth, tenant, and user actions using ensureSuccess

## Testing
- `npm test` *(fails: Invalid input expected string received undefined)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8252e2eb88322b38e32cdb45f4355