### PR TITLE
refactor: consolidate API types

### DIFF
--- a/src/actions/tenants.ts
+++ b/src/actions/tenants.ts
@@ -4,8 +4,7 @@
 
 import { apiRequest } from "./api";
 import { API_ENDPOINTS } from "@/constants/api";
-import type { Tenant, User } from "@/lib/types";
-import type { ApiResponse } from "@/types/api";
+import type { ApiResponse, Tenant, User } from "@/types/api";
 import { ensureSuccess } from "@/lib/api";
 import {
   listTenants as listTenantsService,

--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -4,8 +4,7 @@
 
 import { apiRequest } from "./api";
 import { API_ENDPOINTS } from "@/constants/api";
-import type { User } from "@/lib/types";
-import type { ApiResponse } from "@/types/api";
+import type { ApiResponse, User } from "@/types/api";
 import { ensureSuccess } from "@/lib/api";
 import {
   listUsers as listUsersService,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,14 +2,6 @@
 
 export type UserRole = "vendor" | "koperasi" | "umkm" | "bumdes";
 
-export interface User {
-  id: string;
-  email: string;
-  name: string;
-  role: UserRole;
-  organizationId?: string;
-}
-
 export interface DashboardStats {
   title: string;
   value: string | number;
@@ -17,10 +9,13 @@ export interface DashboardStats {
   trend?: "up" | "down" | "neutral";
 }
 
-export interface Tenant {
-  id: string | number;
-  name: string;
-  type: string;
-  domain: string;
-  status: string;
-}
+// Re-export API types to keep a single source of truth
+export type {
+  User,
+  Tenant,
+  Role,
+  Plan,
+  Invoice,
+  Payment,
+  LoginResponse,
+} from "@/types/api";

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -7,8 +7,17 @@ import {
 } from "./auth";
 import { API_ENDPOINTS } from "@/constants/api";
 import { env } from "@/lib/env";
-import type { ApiResponse } from "@/types/api";
-import type { Tenant, User } from "@/lib/types";
+import type {
+  ApiResponse,
+  LoginResponse,
+  RefreshResponse,
+  Tenant,
+  User,
+  Role,
+  Plan,
+  Invoice,
+  Payment,
+} from "@/types/api";
 
 export async function getTenantId(): Promise<string | null> {
   if (typeof window !== "undefined") {
@@ -95,13 +104,13 @@ export const api = {
 export function login(payload: {
   email: string;
   password: string;
-}): Promise<ApiResponse<any>> {
+}): Promise<ApiResponse<LoginResponse>> {
   return api.post(`${API_PREFIX}${API_ENDPOINTS.auth.login}`, payload);
 }
 
 export function refreshToken(payload: {
   refresh_token: string;
-}): Promise<ApiResponse<any>> {
+}): Promise<ApiResponse<RefreshResponse>> {
   return api.post(`${API_PREFIX}${API_ENDPOINTS.auth.refresh}`, payload);
 }
 
@@ -142,13 +151,6 @@ export function resetPassword(payload: {
   );
 }
 
-interface Role {
-  id: string | number;
-  name: string;
-  description?: string;
-  tenant_id?: string | number;
-}
-
 export function listRoles(): Promise<ApiResponse<Role[]>> {
   return api.get(`${API_PREFIX}${API_ENDPOINTS.roles.list}`);
 }
@@ -163,22 +165,22 @@ export function assignRole(
   );
 }
 
-export function listVendorPlans(): Promise<ApiResponse<any[]>> {
+export function listVendorPlans(): Promise<ApiResponse<Plan[]>> {
   return api.get(`${API_PREFIX}${API_ENDPOINTS.billing.vendor.plans}`);
 }
 
-export function listVendorInvoices(): Promise<ApiResponse<any[]>> {
+export function listVendorInvoices(): Promise<ApiResponse<Invoice[]>> {
   return api.get(`${API_PREFIX}${API_ENDPOINTS.billing.vendor.invoices}`);
 }
 
-export function listClientInvoices(): Promise<ApiResponse<any[]>> {
+export function listClientInvoices(): Promise<ApiResponse<Invoice[]>> {
   return api.get(`${API_PREFIX}${API_ENDPOINTS.billing.client.invoices}`);
 }
 
 export function createPayment(
   invoiceId: string | number,
-  payload: any
-): Promise<ApiResponse<any>> {
+  payload: Partial<Payment>
+): Promise<ApiResponse<Payment>> {
   return api.post(
     `${API_PREFIX}${API_ENDPOINTS.billing.client.invoice(invoiceId).payments}`,
     payload

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,21 +1,162 @@
 export interface Pagination {
-  next_cursor: string | null;
-  prev_cursor: string | null;
+  next_cursor?: string;
+  prev_cursor?: string;
   has_next: boolean;
   has_prev: boolean;
   limit: number;
 }
 
-export interface ApiMeta {
-  pagination: Pagination | null;
+export interface Meta {
+  pagination?: Pagination;
   request_id: string;
-  timestamp: string;
+  timestamp: string; // ISO 8601
 }
 
 export interface ApiResponse<T> {
   success: boolean;
   message: string;
-  data: T | null;
-  meta: ApiMeta;
-  errors: Record<string, string[]> | null;
+  data: T;
+  meta: Meta;
+  errors: unknown;
 }
+
+export interface LoginResponse {
+  id: number;
+  nama: string;
+  role: string;
+  jenis_tenant: string;
+  email: string;
+  access_token: string;
+  refresh_token: string;
+  expires_at: number;
+}
+
+export interface RefreshResponse {
+  access_token: string;
+}
+
+export interface Plan {
+  id: number;
+  name: string;
+  price: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface InvoiceItem {
+  id: number;
+  invoice_id: number;
+  description: string;
+  quantity: number;
+  price: number;
+}
+
+export interface Invoice {
+  id: number;
+  tenant_id: number;
+  number: string;
+  issued_at: string;
+  due_date?: string | null;
+  total: number;
+  status: string;
+  items: InvoiceItem[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Payment {
+  id: number;
+  invoice_id: number;
+  method: string;
+  proof_url: string;
+  status: string;
+  created_at: string;
+}
+
+export interface Tenant {
+  id: number;
+  name: string;
+  domain: string;
+  type: string;
+  is_active: boolean;
+  created_at: string;
+  updated_at?: string;
+}
+
+export interface Role {
+  id: number;
+  name: string;
+  description: string;
+  tenant_id: number;
+  created_at: string;
+  updated_at: string;
+  tenant: Tenant;
+}
+
+export interface RoleUser {
+  id: number;
+  user_id: number;
+  role_id: number;
+  tenant_id: number;
+  created_at: string;
+  updated_at: string;
+  role: Role;
+}
+
+export interface CasbinRule {
+  id: number;
+  p_type: string;
+  v0: string;
+  v1: string;
+  v2: string;
+  v3: string;
+  v4: string;
+  v5: string;
+}
+
+export interface UserTenantAccess {
+  id: string;
+  user_id: number;
+  tenant_id: number;
+  role_id: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Module {
+  id: string;
+  name: string;
+  code: string;
+  description: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TenantModule {
+  id: string;
+  tenant_id: number;
+  module_id: string;
+  status: string;
+  start_date?: string | null;
+  end_date?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface User {
+  id: number;
+  tenant_id: number;
+  role_id: number;
+  email: string;
+  password_hash: string;
+  full_name: string;
+  status: boolean;
+  last_login?: string | null;
+  created_at: string;
+  updated_at: string;
+  tenant: Tenant;
+  role: Role;
+}
+
+export type StringMap = Record<string, string>;
+export type NumberMap = Record<string, number>;

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,6 +1,6 @@
 /** @format */
 
-import { User } from "@/lib/types";
+import type { User } from "@/types/api";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import NextAuth from "next-auth";
 


### PR DESCRIPTION
## Summary
- centralize API interfaces (LoginResponse, Tenant, User, Role, Plan, Invoice, Payment)
- re-export API types from lib and update services/actions to use unified types

## Testing
- `npm test` *(fails: Invalid input errors for env vars and missing request scope)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a829a7d4c483229de6ce26189af35d