### PR TITLE
feat: vendor billing pages and placeholder dashboards

### DIFF
--- a/src/actions/billing.ts
+++ b/src/actions/billing.ts
@@ -7,6 +7,7 @@ import {
   listVendorInvoices,
   listClientInvoices,
   createPayment,
+  listVendorPlans,
 } from "@/services/api";
 
 export async function listInvoicesAction(
@@ -33,4 +34,13 @@ export async function createPaymentAction(
 
 export type CreatePaymentActionResult = Awaited<
   ReturnType<typeof createPaymentAction>
+>;
+
+export async function listVendorPlansAction() {
+  const res = await listVendorPlans();
+  return ensureSuccess(res);
+}
+
+export type ListVendorPlansActionResult = Awaited<
+  ReturnType<typeof listVendorPlansAction>
 >;

--- a/src/app/(main)/vendor/invoices/page.tsx
+++ b/src/app/(main)/vendor/invoices/page.tsx
@@ -11,35 +11,11 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { FileText, Plus, Search, Download, Eye } from "lucide-react";
+import { listInvoicesAction } from "@/actions/billing";
 
-const invoices = [
-  {
-    id: "INV-001",
-    client: "PT Maju Jaya",
-    amount: "Rp 2,450,000",
-    date: "2024-01-15",
-    dueDate: "2024-02-15",
-    status: "paid",
-  },
-  {
-    id: "INV-002",
-    client: "CV Berkah Sejahtera",
-    amount: "Rp 1,750,000",
-    date: "2024-01-20",
-    dueDate: "2024-02-20",
-    status: "pending",
-  },
-  {
-    id: "INV-003",
-    client: "UD Mandiri",
-    amount: "Rp 890,000",
-    date: "2024-01-25",
-    dueDate: "2024-02-25",
-    status: "overdue",
-  },
-];
+export default async function InvoicesPage() {
+  const invoices = await listInvoicesAction("vendor");
 
-export default function InvoicesPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
@@ -84,19 +60,21 @@ export default function InvoicesPage() {
                     <FileText className="h-6 w-6" />
                   </div>
                   <div>
-                    <h3 className="font-medium">{invoice.id}</h3>
+                    <h3 className="font-medium">{invoice.number}</h3>
                     <p className="text-sm text-muted-foreground">
-                      {invoice.client}
+                      {invoice.issued_at}
                     </p>
                   </div>
                 </div>
 
                 <div className="flex items-center gap-6">
                   <div className="text-right">
-                    <p className="font-medium">{invoice.amount}</p>
-                    <p className="text-sm text-muted-foreground">
-                      Due: {invoice.dueDate}
-                    </p>
+                    <p className="font-medium">Rp {invoice.total}</p>
+                    {invoice.due_date && (
+                      <p className="text-sm text-muted-foreground">
+                        Due: {invoice.due_date}
+                      </p>
+                    )}
                   </div>
 
                   <Badge

--- a/src/app/(main)/vendor/plans/page.tsx
+++ b/src/app/(main)/vendor/plans/page.tsx
@@ -1,0 +1,28 @@
+/** @format */
+
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { listVendorPlansAction } from "@/actions/billing";
+
+export default async function PlansPage() {
+  const plans = await listVendorPlansAction();
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Available Plans</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ul className="list-disc pl-4">
+            {plans.map((plan) => (
+              <li key={plan.id}>
+                {plan.name} - Rp {plan.price}
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- load vendor plans and invoices using server actions
- add server-rendered pages for vendor plans and invoices
- keep dashboards static placeholders until related endpoints are available

## Testing
- `npm test` *(fails: ZodError: Invalid input: expected string, received undefined)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a82b6a8c9883229596e314fec1bf33