### PR TITLE
fix: prevent window access on server

### DIFF
--- a/src/actions/api.ts
+++ b/src/actions/api.ts
@@ -13,7 +13,12 @@ export async function apiRequest<T = any>(
   options?: RequestInit
 ): Promise<ApiResponse<T>> {
   const session = (await getServerSession(authOptions)) as UserSession;
-  const tenantId = (await cookies()).get("tenantId")?.value;
+  let tenantId: string | undefined;
+  try {
+    tenantId = (await cookies()).get("tenantId")?.value;
+  } catch {
+    tenantId = undefined;
+  }
   let token = session?.accessToken;
 
   const request = async (access?: string) =>


### PR DESCRIPTION
## Summary
- load next-auth utilities lazily and fall back to server session APIs so `window` is never referenced during SSR
- guard tenant cookie lookup to avoid runtime errors when no request context exists

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a8319454988322a1b3991bd484adc5