### PR TITLE
refactor: prevent NEXTAUTH_SECRET from client exposure

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,7 +7,6 @@ const nextConfig: NextConfig = {
     NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
     NEXT_PUBLIC_BASE_URL: process.env.NEXT_PUBLIC_BASE_URL,
     NEXTAUTH_URL: process.env.NEXTAUTH_URL,
-    NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
     NEXTAUTH_URL_INTERNAL: process.env.NEXTAUTH_URL_INTERNAL,
   },
 };


### PR DESCRIPTION
## Summary
- remove `NEXTAUTH_SECRET` from Next.js `env` config
- rely on `process.env.NEXTAUTH_SECRET` at runtime on the server

## Testing
- `npm test -- --run`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a85299380083228e22439ac754bfc6