### PR TITLE
feat: validate NEXTAUTH_SECRET at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Dashboard menyediakan rute awal untuk modul-modul berikut:
    NEXTAUTH_SECRET=your_secret_key
    NEXTAUTH_URL_INTERNAL=http://localhost:3000
    ```
+   Aplikasi akan langsung gagal dijalankan jika `NEXTAUTH_SECRET`
+   belum dikonfigurasi.
 3. Jalankan server pengembangan:
    ```bash
    npm run dev

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -2,6 +2,7 @@
 import { AuthOptions } from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 import { getTenantId } from "@/services/api";
+import { NEXTAUTH_SECRET } from "@/lib/env";
 
 export async function refreshAccessToken(token: any) {
   try {
@@ -120,5 +121,5 @@ export const authOptions: AuthOptions = {
     signOut: "/auth/login",
   },
 
-  secret: process.env.NEXTAUTH_SECRET,
+  secret: NEXTAUTH_SECRET,
 };

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,12 @@
+/** @format */
+
+export function getNextAuthSecret(): string {
+  const secret = process.env.NEXTAUTH_SECRET;
+  if (!secret) {
+    throw new Error('NEXTAUTH_SECRET is not configured');
+  }
+  return secret;
+}
+
+export const NEXTAUTH_SECRET = getNextAuthSecret();
+

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,6 +3,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { getToken } from "next-auth/jwt";
+import { NEXTAUTH_SECRET } from "@/lib/env";
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -56,7 +57,7 @@ export async function middleware(request: NextRequest) {
   // cek token NextAuth
   const token = await getToken({
     req: request,
-    secret: process.env.NEXTAUTH_SECRET,
+    secret: NEXTAUTH_SECRET,
   });
   const userRole = (token as any)?.jenis_tenant;
 


### PR DESCRIPTION
## Summary
- add env helper that ensures NEXTAUTH_SECRET exists
- use env helper in auth options and middleware
- document that missing NEXTAUTH_SECRET will crash startup

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8529a817083229e36f2e5a045ea56