### PR TITLE
Handle server fetch errors gracefully

### DIFF
--- a/src/__tests__/api-service.spec.ts
+++ b/src/__tests__/api-service.spec.ts
@@ -2,7 +2,7 @@
 
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { api, ApiError, getTenantId } from "@/services/api";
+import { api, getTenantId } from "@/services/api";
 import { getAccessToken, refreshToken, logout } from "@/services/auth";
 
 vi.mock("@/services/auth", () => ({
@@ -62,15 +62,12 @@ describe("api service", () => {
         json: async () => ({ error: "unauthorized" }),
       }) as any;
 
-    const promise = api.get("/test");
-    await expect(promise).rejects.toBeInstanceOf(ApiError);
-    await promise.catch((err) => {
-      expect((err as any).status).toBe(401);
-    });
+    const result = await api.get("/test");
+    expect(result.success).toBe(false);
     expect(logout).toHaveBeenCalled();
   });
 
-  it("throws ApiError for non-ok response", async () => {
+  it("returns error response for non-ok status", async () => {
     (getAccessToken as any).mockResolvedValue(null);
 
     global.fetch = vi
@@ -82,12 +79,9 @@ describe("api service", () => {
         json: async () => ({ message: "boom" }),
       }) as any;
 
-    const promise = api.get("/err");
-    await expect(promise).rejects.toBeInstanceOf(ApiError);
-    await promise.catch((err) => {
-      expect((err as any).status).toBe(500);
-      expect((err as any).data).toEqual({ message: "boom" });
-    });
+    const result = await api.get("/err");
+    expect(result.success).toBe(false);
+    expect(result.message).toBe("boom");
   });
 
   it("getTenantId reads from cookie", async () => {

--- a/src/__tests__/api.spec.ts
+++ b/src/__tests__/api.spec.ts
@@ -30,20 +30,18 @@ describe("apiFetch", () => {
   it.each([
     [404, "Not Found"],
     [500, "Server Error"],
-  ])("throws error for status %s", async (status, message) => {
+  ])("returns null for status %s", async (status, message) => {
     global.fetch = vi
       .fn()
       .mockResolvedValue({
         ok: false,
         status,
+        statusText: message,
         json: async () => ({ message }),
       }) as any;
 
-    const promise = apiFetch("/test");
-    await expect(promise).rejects.toThrow(message);
-    await promise.catch((err) => {
-      expect((err as any).status).toBe(status);
-    });
+    const result = await apiFetch("/test");
+    expect(result).toBeNull();
   });
 });
 

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -17,7 +17,10 @@ export async function refreshAccessToken(token: any) {
     const json = await res.json().catch(() => null);
     const data = json?.data;
 
-    if (!res.ok || !data) throw new Error("Refresh token failed");
+    if (!res.ok || !data) {
+      console.error("refreshAccessToken failed", res.status, json);
+      return { ...token, error: "RefreshAccessTokenError" };
+    }
 
     return {
       ...token,


### PR DESCRIPTION
## Summary
- avoid throwing in refreshAccessToken and return token with error info
- add resilient apiRequest/apiFetch wrappers that return structured failure responses
- wrap generic service request to return ApiResponse with success flag instead of throwing

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68a8af4bc7748322acccc76b17d98618