### PR TITLE
feat: add vendor plan CRUD operations

### DIFF
--- a/src/actions/billing.ts
+++ b/src/actions/billing.ts
@@ -8,6 +8,10 @@ import {
   listClientInvoices,
   createPayment,
   listVendorPlans,
+  createVendorPlan,
+  getVendorPlan,
+  updateVendorPlan,
+  deleteVendorPlan,
 } from "@/services/api";
 
 export async function listInvoicesAction(type: "vendor" | "client" = "client") {
@@ -46,4 +50,43 @@ export async function listVendorPlansAction() {
 
 export type ListVendorPlansActionResult = Awaited<
   ReturnType<typeof listVendorPlansAction>
+>;
+
+export async function createVendorPlanAction(payload: any) {
+  const res = await createVendorPlan(payload);
+  return ensureSuccess(res);
+}
+
+export type CreateVendorPlanActionResult = Awaited<
+  ReturnType<typeof createVendorPlanAction>
+>;
+
+export async function getVendorPlanAction(id: string | number) {
+  const res = await getVendorPlan(id);
+  return ensureSuccess(res);
+}
+
+export type GetVendorPlanActionResult = Awaited<
+  ReturnType<typeof getVendorPlanAction>
+>;
+
+export async function updateVendorPlanAction(
+  id: string | number,
+  payload: any,
+) {
+  const res = await updateVendorPlan(id, payload);
+  return ensureSuccess(res);
+}
+
+export type UpdateVendorPlanActionResult = Awaited<
+  ReturnType<typeof updateVendorPlanAction>
+>;
+
+export async function deleteVendorPlanAction(id: string | number) {
+  const res = await deleteVendorPlan(id);
+  return ensureSuccess(res);
+}
+
+export type DeleteVendorPlanActionResult = Awaited<
+  ReturnType<typeof deleteVendorPlanAction>
 >;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -202,6 +202,41 @@ export function listVendorPlans(): Promise<ApiResponse<Plan[]>> {
   );
 }
 
+export function createVendorPlan(
+  payload: Partial<Plan>,
+): Promise<ApiResponse<Plan>> {
+  return api.post<Plan>(
+    `${API_PREFIX}${API_ENDPOINTS.billing.vendor.plans}`,
+    payload,
+  );
+}
+
+export function getVendorPlan(
+  id: string | number,
+): Promise<ApiResponse<Plan>> {
+  return api.get<Plan>(
+    `${API_PREFIX}${API_ENDPOINTS.billing.vendor.plan(id)}`,
+  );
+}
+
+export function updateVendorPlan(
+  id: string | number,
+  payload: Partial<Plan>,
+): Promise<ApiResponse<Plan>> {
+  return api.put<Plan>(
+    `${API_PREFIX}${API_ENDPOINTS.billing.vendor.plan(id)}`,
+    payload,
+  );
+}
+
+export function deleteVendorPlan(
+  id: string | number,
+): Promise<ApiResponse<any>> {
+  return api.delete<any>(
+    `${API_PREFIX}${API_ENDPOINTS.billing.vendor.plan(id)}`,
+  );
+}
+
 export function listVendorInvoices(): Promise<ApiResponse<Invoice[]>> {
   return api.get<Invoice[]>(
     `${API_PREFIX}${API_ENDPOINTS.billing.vendor.invoices}`,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -41,6 +41,7 @@ export interface Plan {
   id: number;
   name: string;
   price: number;
+  duration_months?: number;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary
- add service functions for vendor plan CRUD
- add action wrappers for vendor plan CRUD
- extend Plan type with duration months

## Testing
- `npm test` *(fails: Failed to load url /workspace/koperasi-digital-dashboard/src/setupTests.ts)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aab40e02bc8322b6041d7b2246801c