### PR TITLE
feat: add notifications module support

### DIFF
--- a/src/actions/notifications.ts
+++ b/src/actions/notifications.ts
@@ -1,0 +1,80 @@
+/** @format */
+
+"use server";
+
+import { apiRequest } from "./api";
+import { API_ENDPOINTS } from "@/constants/api";
+import type { ApiResponse, Notification } from "@/types/api";
+import { ensureSuccess } from "@/lib/api";
+import {
+  listNotifications as listNotificationsService,
+  createNotification as createNotificationService,
+  updateNotificationStatus as updateNotificationStatusService,
+} from "@/services/api";
+
+export async function listNotifications(params?: {
+  limit?: number;
+  cursor?: string;
+}): Promise<ApiResponse<Notification[]>> {
+  const search = new URLSearchParams();
+  if (params?.limit) search.set("limit", String(params.limit));
+  if (params?.cursor) search.set("cursor", params.cursor);
+  const endpoint = search.toString()
+    ? `${API_ENDPOINTS.notifications.list}?${search.toString()}`
+    : API_ENDPOINTS.notifications.list;
+  return apiRequest<Notification[]>(endpoint);
+}
+
+export async function createNotification(payload: {
+  title: string;
+  message: string;
+}): Promise<ApiResponse<Notification>> {
+  return apiRequest<Notification>(API_ENDPOINTS.notifications.create, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function updateNotificationStatus(
+  id: string | number,
+  payload: { status: string },
+): Promise<ApiResponse<Notification>> {
+  return apiRequest<Notification>(API_ENDPOINTS.notifications.status(id), {
+    method: "PATCH",
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function listNotificationsAction(
+  params?: Record<string, string | number>,
+) {
+  const res = await listNotificationsService(params);
+  return ensureSuccess(res);
+}
+
+export type ListNotificationsActionResult = Awaited<
+  ReturnType<typeof listNotificationsAction>
+>;
+
+export async function createNotificationAction(
+  payload: Partial<Notification>,
+) {
+  const res = await createNotificationService(payload);
+  return ensureSuccess(res);
+}
+
+export type CreateNotificationActionResult = Awaited<
+  ReturnType<typeof createNotificationAction>
+>;
+
+export async function updateNotificationStatusAction(
+  id: string | number,
+  payload: { status: string },
+) {
+  const res = await updateNotificationStatusService(id, payload);
+  return ensureSuccess(res);
+}
+
+export type UpdateNotificationStatusActionResult = Awaited<
+  ReturnType<typeof updateNotificationStatusAction>
+>;

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -30,6 +30,11 @@ export const API_ENDPOINTS = {
     permission: (id: string | number, pid: string | number) =>
       `/roles/${id}/permissions/${pid}`,
   },
+  notifications: {
+    list: "/notifications",
+    create: "/notifications",
+    status: (id: string | number) => `/notifications/${id}/status`,
+  },
   billing: {
     vendor: {
       plans: "/vendor/plans",

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,0 +1,15 @@
+/** @format */
+
+export const RegisterModules = [
+  "members",
+  "savings",
+  "savings.syariah",
+  "loans",
+  "financing",
+  "shu",
+  "rat",
+  "assets",
+  "transactions",
+  "billing",
+  "notifications",
+] as const;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -16,6 +16,7 @@ import type {
   Plan,
   Invoice,
   Payment,
+  Notification,
 } from "@/types/api";
 
 export async function getTenantId(): Promise<string | null> {
@@ -107,6 +108,8 @@ export const api = {
     request<T>(path, { ...options, method: "POST", body }),
   put: <T>(path: string, body?: any, options?: RequestInit) =>
     request<T>(path, { ...options, method: "PUT", body }),
+  patch: <T>(path: string, body?: any, options?: RequestInit) =>
+    request<T>(path, { ...options, method: "PATCH", body }),
   delete: <T>(path: string, options?: RequestInit) =>
     request<T>(path, { ...options, method: "DELETE" }),
 };
@@ -192,6 +195,36 @@ export function assignRole(
 ): Promise<ApiResponse<any>> {
   return api.post<any>(
     `${API_PREFIX}${API_ENDPOINTS.users.roles(userId)}`,
+    payload,
+  );
+}
+
+export function listNotifications(
+  params?: Record<string, string | number>
+): Promise<ApiResponse<Notification[]>> {
+  const query = params
+    ? `?${new URLSearchParams(params as any).toString()}`
+    : "";
+  return api.get<Notification[]>(
+    `${API_PREFIX}${API_ENDPOINTS.notifications.list}${query}`,
+  );
+}
+
+export function createNotification(
+  payload: Partial<Notification>
+): Promise<ApiResponse<Notification>> {
+  return api.post<Notification>(
+    `${API_PREFIX}${API_ENDPOINTS.notifications.create}`,
+    payload,
+  );
+}
+
+export function updateNotificationStatus(
+  id: string | number,
+  payload: { status: string }
+): Promise<ApiResponse<Notification>> {
+  return api.patch<Notification>(
+    `${API_PREFIX}${API_ENDPOINTS.notifications.status(id)}`,
     payload,
   );
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -161,5 +161,14 @@ export interface User {
   role: Role;
 }
 
+export interface Notification {
+  id: number;
+  title: string;
+  message: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
 export type StringMap = Record<string, string>;
 export type NumberMap = Record<string, number>;


### PR DESCRIPTION
## Summary
- add notification endpoints to API constants
- define `Notification` type and service functions
- expose server actions and register module

## Testing
- `npm run lint`
- `npm test -- --run` *(fails: Failed to load url src/setupTests.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68aab41315088322ba61eb9ebcaad8b7