### PR TITLE
feat: send refresh token on logout

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -130,8 +130,13 @@ export function refreshToken(payload: {
   );
 }
 
-export function logout(): Promise<ApiResponse<any>> {
-  return api.post<any>(`${API_PREFIX}${API_ENDPOINTS.auth.logout}`);
+export function logout(payload: {
+  refresh_token: string;
+}): Promise<ApiResponse<any>> {
+  return api.post<any>(
+    `${API_PREFIX}${API_ENDPOINTS.auth.logout}`,
+    payload,
+  );
 }
 
 export function listTenants(


### PR DESCRIPTION
## Summary
- include refresh token in logout API call
- fetch refresh token in logout action and handle missing token

## Testing
- `npm test` *(fails: Failed to load url /workspace/koperasi-digital-dashboard/src/setupTests.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68aab3c69e50832282a94da414670272