### PR TITLE
feat: add vendor invoice endpoints

### DIFF
--- a/src/actions/billing.ts
+++ b/src/actions/billing.ts
@@ -5,6 +5,9 @@
 import { ensureSuccess } from "@/lib/api";
 import {
   listVendorInvoices,
+  createVendorInvoice,
+  updateVendorInvoice,
+  deleteVendorInvoice,
   listClientInvoices,
   createPayment,
   listVendorPlans,
@@ -41,6 +44,36 @@ export async function createPaymentAction(
 
 export type CreatePaymentActionResult = Awaited<
   ReturnType<typeof createPaymentAction>
+>;
+
+export async function createVendorInvoiceAction(payload: any) {
+  const res = await createVendorInvoice(payload);
+  return ensureSuccess(res);
+}
+
+export type CreateVendorInvoiceActionResult = Awaited<
+  ReturnType<typeof createVendorInvoiceAction>
+>;
+
+export async function updateVendorInvoiceAction(
+  id: string | number,
+  payload: any,
+) {
+  const res = await updateVendorInvoice(id, payload);
+  return ensureSuccess(res);
+}
+
+export type UpdateVendorInvoiceActionResult = Awaited<
+  ReturnType<typeof updateVendorInvoiceAction>
+>;
+
+export async function deleteVendorInvoiceAction(id: string | number) {
+  const res = await deleteVendorInvoice(id);
+  return ensureSuccess(res);
+}
+
+export type DeleteVendorInvoiceActionResult = Awaited<
+  ReturnType<typeof deleteVendorInvoiceAction>
 >;
 
 export async function listVendorPlansAction() {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -360,6 +360,33 @@ export function listVendorInvoices(): Promise<ApiResponse<Invoice[]>> {
   );
 }
 
+export function createVendorInvoice(
+  payload: Partial<Invoice>,
+): Promise<ApiResponse<Invoice>> {
+  return api.post<Invoice>(
+    `${API_PREFIX}${API_ENDPOINTS.billing.vendor.invoices}`,
+    payload,
+  );
+}
+
+export function updateVendorInvoice(
+  id: string | number,
+  payload: Partial<Invoice>,
+): Promise<ApiResponse<Invoice>> {
+  return api.put<Invoice>(
+    `${API_PREFIX}${API_ENDPOINTS.billing.vendor.invoice(id)}`,
+    payload,
+  );
+}
+
+export function deleteVendorInvoice(
+  id: string | number,
+): Promise<ApiResponse<any>> {
+  return api.delete<any>(
+    `${API_PREFIX}${API_ENDPOINTS.billing.vendor.invoice(id)}`,
+  );
+}
+
 export function listClientInvoices(): Promise<ApiResponse<Invoice[]>> {
   return api.get<Invoice[]>(
     `${API_PREFIX}${API_ENDPOINTS.billing.client.invoices}`,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -52,6 +52,7 @@ export interface InvoiceItem {
   description: string;
   quantity: number;
   price: number;
+  subscription_id?: number;
 }
 
 export interface Invoice {
@@ -65,6 +66,7 @@ export interface Invoice {
   items: InvoiceItem[];
   created_at: string;
   updated_at: string;
+  subscription_id?: number;
 }
 
 export interface Payment {


### PR DESCRIPTION
## Summary
- add vendor invoice CRUD service functions
- add billing actions for vendor invoices
- extend invoice types with subscription ID

## Testing
- `npm test` (fails: Failed to load url /workspace/koperasi-digital-dashboard/src/setupTests.ts)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aaba85fb908322b7a2131fcfc3d2c6