### PR TITLE
feat: add refresh token action

### DIFF
--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -5,7 +5,11 @@
 import { apiFetch } from "./api";
 import { API_ENDPOINTS } from "@/constants/api";
 import { ensureSuccess } from "@/lib/api";
-import { login as loginService, logout as logoutService } from "@/services/api";
+import {
+  login as loginService,
+  logout as logoutService,
+  refreshToken as refreshTokenService,
+} from "@/services/api";
 import { cookies } from "next/headers";
 
 export async function login(payload: { email: string; password: string }) {
@@ -35,6 +39,15 @@ export async function loginAction(payload: { email: string; password: string }) 
 }
 
 export type LoginActionResult = Awaited<ReturnType<typeof loginAction>>;
+
+export async function refreshTokenAction(payload: { refresh_token: string }) {
+  const res = await refreshTokenService(payload);
+  return ensureSuccess(res);
+}
+
+export type RefreshTokenActionResult = Awaited<
+  ReturnType<typeof refreshTokenAction>
+>;
 
 export async function logoutAction() {
   let refreshToken: string | undefined;


### PR DESCRIPTION
## Summary
- implement refreshTokenAction to wrap API refresh token service
- export RefreshTokenActionResult

## Testing
- `npm test` *(fails: Failed to load url /workspace/koperasi-digital-dashboard/src/setupTests.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68aabaa1711083229d01accff7f681df