### PR TITLE
feat: add role permission services

### DIFF
--- a/src/actions/role.ts
+++ b/src/actions/role.ts
@@ -3,7 +3,18 @@
 "use server";
 
 import { ensureSuccess } from "@/lib/api";
-import { listRoles, assignRole } from "@/services/api";
+import {
+  listRoles,
+  assignRole,
+  createRole,
+  updateRole,
+  deleteRole,
+  listRolePermissions,
+  addRolePermission,
+  deleteRolePermission,
+  removeUserRole,
+} from "@/services/api";
+import type { Role, Permission } from "@/types/api";
 
 export async function listRolesAction() {
   const res = await listRoles();
@@ -24,4 +35,85 @@ export async function assignRoleAction(
 
 export type AssignRoleActionResult = Awaited<
   ReturnType<typeof assignRoleAction>
+>;
+
+export async function createRoleAction(
+  payload: Partial<Role>,
+): Promise<Role> {
+  const res = await createRole(payload);
+  return ensureSuccess(res);
+}
+
+export type CreateRoleActionResult = Awaited<
+  ReturnType<typeof createRoleAction>
+>;
+
+export async function updateRoleAction(
+  id: string | number,
+  payload: Partial<Role>,
+): Promise<Role> {
+  const res = await updateRole(id, payload);
+  return ensureSuccess(res);
+}
+
+export type UpdateRoleActionResult = Awaited<
+  ReturnType<typeof updateRoleAction>
+>;
+
+export async function deleteRoleAction(
+  id: string | number,
+): Promise<{ id: number }> {
+  const res = await deleteRole(id);
+  return ensureSuccess(res);
+}
+
+export type DeleteRoleActionResult = Awaited<
+  ReturnType<typeof deleteRoleAction>
+>;
+
+export async function listRolePermissionsAction(
+  id: string | number,
+): Promise<Permission[]> {
+  const res = await listRolePermissions(id);
+  return ensureSuccess(res);
+}
+
+export type ListRolePermissionsActionResult = Awaited<
+  ReturnType<typeof listRolePermissionsAction>
+>;
+
+export async function addRolePermissionAction(
+  id: string | number,
+  payload: { obj: string; act: string },
+): Promise<Permission> {
+  const res = await addRolePermission(id, payload);
+  return ensureSuccess(res);
+}
+
+export type AddRolePermissionActionResult = Awaited<
+  ReturnType<typeof addRolePermissionAction>
+>;
+
+export async function deleteRolePermissionAction(
+  roleId: string | number,
+  permissionId: string | number,
+): Promise<{ id: number }> {
+  const res = await deleteRolePermission(roleId, permissionId);
+  return ensureSuccess(res);
+}
+
+export type DeleteRolePermissionActionResult = Awaited<
+  ReturnType<typeof deleteRolePermissionAction>
+>;
+
+export async function removeUserRoleAction(
+  userId: string | number,
+  roleId: string | number,
+): Promise<{ id: number }> {
+  const res = await removeUserRole(userId, roleId);
+  return ensureSuccess(res);
+}
+
+export type RemoveUserRoleActionResult = Awaited<
+  ReturnType<typeof removeUserRoleAction>
 >;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -13,6 +13,7 @@ import type {
   Tenant,
   User,
   Role,
+  Permission,
   Plan,
   Invoice,
   Payment,
@@ -273,6 +274,60 @@ export function listRoles(): Promise<ApiResponse<Role[]>> {
   return api.get<Role[]>(`${API_PREFIX}${API_ENDPOINTS.roles.list}`);
 }
 
+export function createRole(
+  payload: Partial<Role>,
+): Promise<ApiResponse<Role>> {
+  return api.post<Role>(
+    `${API_PREFIX}${API_ENDPOINTS.roles.list}`,
+    payload,
+  );
+}
+
+export function updateRole(
+  id: string | number,
+  payload: Partial<Role>,
+): Promise<ApiResponse<Role>> {
+  return api.put<Role>(
+    `${API_PREFIX}${API_ENDPOINTS.roles.detail(id)}`,
+    payload,
+  );
+}
+
+export function deleteRole(
+  id: string | number,
+): Promise<ApiResponse<{ id: number }>> {
+  return api.delete<{ id: number }>(
+    `${API_PREFIX}${API_ENDPOINTS.roles.detail(id)}`,
+  );
+}
+
+export function listRolePermissions(
+  id: string | number,
+): Promise<ApiResponse<Permission[]>> {
+  return api.get<Permission[]>(
+    `${API_PREFIX}${API_ENDPOINTS.roles.permissions(id)}`,
+  );
+}
+
+export function addRolePermission(
+  id: string | number,
+  payload: { obj: string; act: string },
+): Promise<ApiResponse<Permission>> {
+  return api.post<Permission>(
+    `${API_PREFIX}${API_ENDPOINTS.roles.permissions(id)}`,
+    payload,
+  );
+}
+
+export function deleteRolePermission(
+  roleId: string | number,
+  permissionId: string | number,
+): Promise<ApiResponse<{ id: number }>> {
+  return api.delete<{ id: number }>(
+    `${API_PREFIX}${API_ENDPOINTS.roles.permission(roleId, permissionId)}`,
+  );
+}
+
 export function assignRole(
   userId: string | number,
   payload: { role_id: string | number; tenant_id?: string | number }
@@ -280,6 +335,15 @@ export function assignRole(
   return api.post<any>(
     `${API_PREFIX}${API_ENDPOINTS.users.roles(userId)}`,
     payload,
+  );
+}
+
+export function removeUserRole(
+  userId: string | number,
+  roleId: string | number,
+): Promise<ApiResponse<{ id: number }>> {
+  return api.delete<{ id: number }>(
+    `${API_PREFIX}${API_ENDPOINTS.users.role(userId, roleId)}`,
   );
 }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -118,6 +118,17 @@ export interface CasbinRule {
   v5: string;
 }
 
+export interface Permission {
+  id: number;
+  ptype: string;
+  v0: string;
+  v1: string;
+  v2: string;
+  v3: string;
+  v4?: string;
+  v5?: string;
+}
+
 export interface UserTenantAccess {
   id: string;
   user_id: number;


### PR DESCRIPTION
## Summary
- expand API services to manage roles and permissions
- add server actions for role CRUD, permissions, and user-role removal
- define Permission API type

## Testing
- `npm test` *(fails: Failed to load url /workspace/koperasi-digital-dashboard/src/setupTests.ts)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aaba92a8c48322bac3a009a851ab3c