### PR TITLE
Handle failed token refresh by logging out

### DIFF
--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -18,8 +18,7 @@ export async function refreshAccessToken(token: any) {
     const data = json?.data;
 
     if (!res.ok || !data) {
-      console.error("refreshAccessToken failed", res.status, json);
-      return { ...token, error: "RefreshAccessTokenError" };
+      return null; // Logout when refresh fails
     }
 
     return {
@@ -31,9 +30,8 @@ export async function refreshAccessToken(token: any) {
       refreshToken: data.refresh_token ?? token.refreshToken,
       error: undefined,
     };
-  } catch (err) {
-    console.error("refreshAccessToken error:", err);
-    return { ...token, error: "RefreshAccessTokenError" };
+  } catch {
+    return null; // Logout on unexpected errors
   }
 }
 


### PR DESCRIPTION
## Summary
- logout when token refresh fails to avoid stale credentials
- remove noisy error logs during refresh

## Testing
- `npm test` (fails: Failed to load url /workspace/koperasi-digital-dashboard/src/setupTests.ts)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab236ee760832292357966e246af94