### PR TITLE
Refactor vendor dashboard layout with shared data provider

### DIFF
--- a/src/app/(main)/vendor/dashboard/page.tsx
+++ b/src/app/(main)/vendor/dashboard/page.tsx
@@ -1,242 +1,112 @@
 /** @format */
 "use client";
 
-import { useMemo, type ReactNode } from "react";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Users, Package, Ticket, InfoIcon, Target, FileText } from "lucide-react";
-import { motion } from "framer-motion";
-import { useVendorDashboard } from "@/hooks/queries/vendor";
-import type { VendorProductTierSummary } from "@/types/api";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { VendorDashboardFilterProvider } from "@/components/feature/vendor/dashboard/vendor-dashboard-filter-context";
+import { VendorDashboardDataProvider, useVendorDashboardData } from "@/components/feature/vendor/dashboard/vendor-dashboard-data-provider";
+import { VendorDashboardGlobalFilters } from "@/components/feature/vendor/dashboard/vendor-dashboard-filters";
+import { VendorDashboardKpiGrid } from "@/components/feature/vendor/dashboard/vendor-dashboard-kpi-grid";
+import { VendorDashboardTierBreakdown } from "@/components/feature/vendor/dashboard/vendor-dashboard-tier-breakdown";
+import { VendorDashboardTicketInsights } from "@/components/feature/vendor/dashboard/vendor-dashboard-ticket-insights";
+import { VendorDashboardUpcomingWidgets } from "@/components/feature/vendor/dashboard/vendor-dashboard-upcoming-widgets";
 
-function formatTierLabel(tier: string) {
-  return tier
-    .replace(/[_-]+/g, " ")
-    .split(" ")
-    .filter(Boolean)
-    .map((chunk) => chunk.charAt(0).toUpperCase() + chunk.slice(1))
-    .join(" ");
+export default function VendorDashboardPage() {
+  return (
+    <VendorDashboardFilterProvider>
+      <VendorDashboardDataProvider>
+        <VendorDashboardPageShell />
+      </VendorDashboardDataProvider>
+    </VendorDashboardFilterProvider>
+  );
 }
 
-export default function VendorDashboard() {
-  const { data: dashboard } = useVendorDashboard();
-
-  const numberFormatter = useMemo(
-    () => new Intl.NumberFormat("id-ID"),
-    []
-  );
-
-  const tiers = useMemo(
-    () =>
-      (dashboard?.client_totals_by_tier ?? []) as VendorProductTierSummary[],
-    [dashboard?.client_totals_by_tier]
-  );
-  const totalClients = useMemo(
-    () => tiers.reduce((acc, tier) => acc + (tier?.active_clients ?? 0), 0),
-    [tiers]
-  );
-
-  const stats = useMemo(() => {
-    const base = [
-      {
-        key: "total-clients",
-        title: "Total Active Clients",
-        value: numberFormatter.format(totalClients),
-        icon: <Users className="h-4 w-4" />,
-      },
-      {
-        key: "open-tickets",
-        title: "Open Tickets",
-        value: numberFormatter.format(dashboard?.open_tickets ?? 0),
-        icon: <Ticket className="h-4 w-4" />,
-      },
-    ];
-
-    const tierCards = tiers.map((tier) => ({
-      key: `tier-${tier.tier}`,
-      title: `${formatTierLabel(tier.tier)} Clients`,
-      value: numberFormatter.format(tier.active_clients ?? 0),
-      icon: <Package className="h-4 w-4" />,
-    }));
-
-    return [...base, ...tierCards];
-  }, [dashboard?.open_tickets, numberFormatter, tiers, totalClients]);
+function VendorDashboardPageShell() {
+  const { isError, error, data, refresh } = useVendorDashboardData();
+  const hasData = Boolean(data);
 
   return (
     <div className="space-y-6">
-      {/* Stats Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-        {stats.map((stat, i) => (
-          <motion.div
-            key={stat.key}
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: i * 0.1, duration: 0.3 }}
-          >
-            <Card>
-              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium">
-                  {stat.title}
-                </CardTitle>
-                {stat.icon}
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">{stat.value}</div>
-              </CardContent>
-            </Card>
-          </motion.div>
-        ))}
-      </div>
+      <header className="space-y-3">
+        <nav aria-label="Breadcrumb">
+          <ol className="flex items-center gap-2 text-sm text-muted-foreground">
+            <li>Vendor</li>
+            <li>/</li>
+            <li className="font-medium text-foreground">Dashboard</li>
+          </ol>
+        </nav>
+        <div className="space-y-1">
+          <h1 className="text-3xl font-semibold tracking-tight">Vendor / Dashboard</h1>
+          <p className="text-sm text-muted-foreground">
+            Ringkasan aktivitas tenant vendor dan status dukungan pelanggan.
+          </p>
+        </div>
+      </header>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <Card>
-          <CardHeader>
-            <CardTitle>Client Insights</CardTitle>
-            <CardDescription>Ticket trends and topline client signals</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="flex items-center justify-between rounded-md border px-4 py-3">
-              <div>
-                <p className="text-sm font-medium">Open Tickets</p>
-                <p className="text-sm text-muted-foreground">
-                  Outstanding support issues across clients
-                </p>
-              </div>
-              <Badge variant="outline" className="text-base font-semibold">
-                {numberFormatter.format(dashboard?.open_tickets ?? 0)}
-              </Badge>
-            </div>
+      {isError ? (
+        <Alert variant="destructive">
+          <AlertTitle>Data dashboard tidak dapat dimuat</AlertTitle>
+          <AlertDescription className="space-y-3">
+            <p>{error?.message ?? "Terjadi kesalahan saat mengambil data dashboard."}</p>
+            <Button size="sm" variant="outline" onClick={() => refresh()}>
+              Coba lagi
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ) : null}
 
-            <div className="space-y-3">
-              <InsightRow
-                icon={<InfoIcon className="h-5 w-5 text-muted-foreground" />}
-                title="Most Active Client"
-                description={dashboard?.most_active_client?.name ?? "No recent client activity"}
-                metric={dashboard?.most_active_client?.ticket_count}
-                metricLabel="tickets"
-              />
-              <InsightRow
-                icon={<Target className="h-5 w-5 text-muted-foreground" />}
-                title="Product With Most Tickets"
-                description={
-                  dashboard?.product_with_most_tickets?.name ?? "No product alerts"
-                }
-                metric={dashboard?.product_with_most_tickets?.ticket_count}
-                metricLabel="tickets"
-              />
-            </div>
+      {!hasData && !isError ? (
+        <Alert>
+          <AlertTitle>Ringkasan belum tersedia</AlertTitle>
+          <AlertDescription>
+            Sistem belum menerima data dashboard vendor. Widget akan diperbarui secara otomatis
+            setelah data tersedia.
+          </AlertDescription>
+        </Alert>
+      ) : null}
 
-            <div>
-              <p className="text-sm font-medium mb-3">Client Distribution</p>
-              <div className="space-y-2">
-                {tiers.length ? (
-                  tiers.map((tier) => (
-                    <div
-                      key={tier.tier}
-                      className="flex items-center justify-between rounded-md bg-muted/40 px-3 py-2 text-sm"
-                    >
-                      <span>{formatTierLabel(tier.tier)}</span>
-                      <span className="font-medium">
-                        {numberFormatter.format(tier.active_clients ?? 0)}
-                      </span>
-                    </div>
-                  ))
-                ) : (
-                  <p className="text-sm text-muted-foreground italic">
-                    No client tier data available.
-                  </p>
-                )}
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+      <VendorDashboardGlobalFilters />
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Quick Actions</CardTitle>
-            <CardDescription>Common tasks and shortcuts</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-2 gap-4">
-              {[
-                {
-                  href: "/vendor/plans",
-                  icon: <Package className="h-6 w-6 mb-2" />,
-                  title: "Add Plan",
-                  desc: "Create new plan",
-                },
-                {
-                  href: "/vendor/invoices",
-                  icon: <FileText className="h-6 w-6 mb-2" />,
-                  title: "Invoices",
-                  desc: "Manage invoices",
-                },
-                {
-                  href: "/vendor/clients",
-                  icon: <Users className="h-6 w-6 mb-2" />,
-                  title: "Clients",
-                  desc: "Manage tenants",
-                },
-                {
-                  href: "/vendor/tickets",
-                  icon: <Ticket className="h-6 w-6 mb-2" />,
-                  title: "Support",
-                  desc: "Support tickets",
-                },
-              ].map((action, index) => (
-                <motion.a
-                  key={index}
-                  href={action.href}
-                  whileHover={{ scale: 1.03 }}
-                  whileTap={{ scale: 0.97 }}
-                  className="p-4 border rounded-lg hover:bg-muted transition-colors block"
-                >
-                  {action.icon}
-                  <p className="font-medium">{action.title}</p>
-                  <p className="text-sm text-muted-foreground">{action.desc}</p>
-                </motion.a>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
+      <div className="grid gap-6">
+        <section>
+          <VendorDashboardKpiGrid />
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-2">
+          <VendorDashboardTierBreakdown />
+          <VendorDashboardTicketInsights />
+        </section>
+
+        <section className="grid gap-6 xl:grid-cols-3">
+          <VendorDashboardUpcomingWidgets />
+          <VendorDashboardPlaceholderCard title="Integrasi Billing" />
+          <VendorDashboardPlaceholderCard title="Aktivitas Produk" />
+        </section>
       </div>
     </div>
   );
 }
 
-function InsightRow({
-  icon,
-  title,
-  description,
-  metric,
-  metricLabel,
-}: {
-  icon: ReactNode;
+type PlaceholderCardProps = {
   title: string;
-  description: string;
-  metric?: number;
-  metricLabel?: string;
-}) {
+};
+
+function VendorDashboardPlaceholderCard({ title }: PlaceholderCardProps) {
   return (
-    <div className="flex items-start gap-3">
-      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
-        {icon}
-      </div>
-      <div className="flex-1 space-y-1">
-        <p className="text-sm font-medium leading-none">{title}</p>
-        <p className="text-sm text-muted-foreground">{description}</p>
-      </div>
-      {typeof metric === "number" && (
-        <Badge variant="secondary" className="text-xs">
-          {metricLabel ? `${metric} ${metricLabel}` : metric}
-        </Badge>
-      )}
-    </div>
+    <Card className="h-full">
+      <CardHeader className="pb-2">
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm text-muted-foreground">
+        <p>Widget akan ditempatkan di sini setelah integrasi backend tersedia.</p>
+        <div className="space-y-2">
+          <Skeleton className="h-3 w-full" />
+          <Skeleton className="h-3 w-2/3" />
+          <Skeleton className="h-3 w-3/4" />
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/components/feature/vendor/dashboard/vendor-dashboard-data-provider.tsx
+++ b/src/components/feature/vendor/dashboard/vendor-dashboard-data-provider.tsx
@@ -1,0 +1,127 @@
+/** @format */
+
+"use client";
+
+import { createContext, useContext, useMemo } from "react";
+import type { ReactNode } from "react";
+import useSWR from "swr";
+import { format as formatDate } from "date-fns";
+
+import { ensureSuccess } from "@/lib/api";
+import { API_PREFIX, api } from "@/services/api";
+import { API_ENDPOINTS } from "@/constants/api";
+import type {
+  VendorClientInsight,
+  VendorDashboard,
+  VendorProductInsight,
+  VendorProductTierSummary,
+} from "@/types/api";
+import {
+  useVendorDashboardFilters,
+  type VendorDashboardFilterState,
+} from "./vendor-dashboard-filter-context";
+
+function buildDashboardQuery(filters: VendorDashboardFilterState): string | null {
+  const params = new URLSearchParams();
+  const { dateRange, tenantType, subscriptionStatus } = filters;
+  if (dateRange?.from) {
+    params.set("start_date", formatDate(dateRange.from, "yyyy-MM-dd"));
+  }
+  if (dateRange?.to) {
+    params.set("end_date", formatDate(dateRange.to, "yyyy-MM-dd"));
+  }
+  if (tenantType && tenantType !== "all") {
+    params.set("tenant_type", tenantType);
+  }
+  if (subscriptionStatus && subscriptionStatus !== "all") {
+    params.set("subscription_status", subscriptionStatus);
+  }
+  const query = params.toString();
+  return query.length ? query : null;
+}
+
+async function fetchVendorDashboard(query?: string | null): Promise<VendorDashboard> {
+  const basePath = `${API_PREFIX}${API_ENDPOINTS.vendor.dashboard}`;
+  const path = query ? `${basePath}?${query}` : basePath;
+  const response = await api.get<VendorDashboard>(path);
+  return ensureSuccess(response);
+}
+
+type VendorDashboardDataContextValue = {
+  data: VendorDashboard | null;
+  tiers: VendorProductTierSummary[];
+  totalActiveClients: number;
+  openTickets: number;
+  mostActiveClient: VendorClientInsight | null;
+  productWithMostTickets: VendorProductInsight | null;
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+  refresh: () => Promise<VendorDashboard | undefined>;
+  isValidating: boolean;
+};
+
+const VendorDashboardDataContext =
+  createContext<VendorDashboardDataContextValue | null>(null);
+
+export function VendorDashboardDataProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const { filters } = useVendorDashboardFilters();
+  const queryKey = useMemo(() => buildDashboardQuery(filters), [filters]);
+
+  const {
+    data,
+    error,
+    isLoading,
+    isValidating,
+    mutate,
+  } = useSWR<VendorDashboard>(
+    ["vendor-dashboard", queryKey],
+    async ([, query]) => fetchVendorDashboard(query),
+    {
+      keepPreviousData: true,
+      revalidateOnFocus: false,
+    },
+  );
+
+  const value = useMemo<VendorDashboardDataContextValue>(() => {
+    const tiers = (data?.client_totals_by_tier ?? []) as VendorProductTierSummary[];
+    const totalActiveClients = tiers.reduce(
+      (total, tier) => total + (tier?.active_clients ?? 0),
+      0,
+    );
+
+    return {
+      data: data ?? null,
+      tiers,
+      totalActiveClients,
+      openTickets: data?.open_tickets ?? 0,
+      mostActiveClient: data?.most_active_client ?? null,
+      productWithMostTickets: data?.product_with_most_tickets ?? null,
+      isLoading,
+      isError: Boolean(error),
+      error: error instanceof Error ? error : error ? new Error(String(error)) : null,
+      refresh: () => mutate(),
+      isValidating,
+    };
+  }, [data, error, isLoading, isValidating, mutate]);
+
+  return (
+    <VendorDashboardDataContext.Provider value={value}>
+      {children}
+    </VendorDashboardDataContext.Provider>
+  );
+}
+
+export function useVendorDashboardData() {
+  const ctx = useContext(VendorDashboardDataContext);
+  if (!ctx) {
+    throw new Error(
+      "useVendorDashboardData must be used within VendorDashboardDataProvider",
+    );
+  }
+  return ctx;
+}

--- a/src/components/feature/vendor/dashboard/vendor-dashboard-filter-context.tsx
+++ b/src/components/feature/vendor/dashboard/vendor-dashboard-filter-context.tsx
@@ -1,0 +1,82 @@
+/** @format */
+
+"use client";
+
+import { createContext, useContext, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+import type { DateRange } from "react-day-picker";
+
+export type VendorTenantTypeFilter = "all" | "koperasi" | "bumdes" | "umkm";
+export type VendorSubscriptionStatusFilter =
+  | "all"
+  | "active"
+  | "trial"
+  | "cancelled"
+  | "expired";
+
+export type VendorDashboardFilterState = {
+  dateRange: DateRange | null;
+  tenantType: VendorTenantTypeFilter;
+  subscriptionStatus: VendorSubscriptionStatusFilter;
+};
+
+const defaultState: VendorDashboardFilterState = {
+  dateRange: null,
+  tenantType: "all",
+  subscriptionStatus: "all",
+};
+
+export type VendorDashboardFilterContextValue = {
+  filters: VendorDashboardFilterState;
+  setDateRange: (range: DateRange | null) => void;
+  setTenantType: (tenantType: VendorTenantTypeFilter) => void;
+  setSubscriptionStatus: (
+    subscriptionStatus: VendorSubscriptionStatusFilter,
+  ) => void;
+  reset: () => void;
+};
+
+const VendorDashboardFilterContext =
+  createContext<VendorDashboardFilterContextValue | null>(null);
+
+export function VendorDashboardFilterProvider({
+  children,
+  initialState,
+}: {
+  children: ReactNode;
+  initialState?: VendorDashboardFilterState;
+}) {
+  const [filters, setFilters] = useState<VendorDashboardFilterState>(
+    initialState ?? defaultState,
+  );
+
+  const value = useMemo<VendorDashboardFilterContextValue>(() => ({
+    filters,
+    setDateRange: (range) => {
+      setFilters((prev) => ({ ...prev, dateRange: range }));
+    },
+    setTenantType: (tenantType) => {
+      setFilters((prev) => ({ ...prev, tenantType }));
+    },
+    setSubscriptionStatus: (subscriptionStatus) => {
+      setFilters((prev) => ({ ...prev, subscriptionStatus }));
+    },
+    reset: () => setFilters(initialState ?? defaultState),
+  }), [filters, initialState]);
+
+  return (
+    <VendorDashboardFilterContext.Provider value={value}>
+      {children}
+    </VendorDashboardFilterContext.Provider>
+  );
+}
+
+export function useVendorDashboardFilters() {
+  const ctx = useContext(VendorDashboardFilterContext);
+  if (!ctx) {
+    throw new Error(
+      "useVendorDashboardFilters must be used within VendorDashboardFilterProvider",
+    );
+  }
+  return ctx;
+}

--- a/src/components/feature/vendor/dashboard/vendor-dashboard-filters.tsx
+++ b/src/components/feature/vendor/dashboard/vendor-dashboard-filters.tsx
@@ -1,0 +1,130 @@
+/** @format */
+
+"use client";
+
+import { RefreshCcw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { DateRangePicker } from "@/components/ui/date-range-picker";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  useVendorDashboardFilters,
+  type VendorSubscriptionStatusFilter,
+  type VendorTenantTypeFilter,
+} from "./vendor-dashboard-filter-context";
+
+const tenantTypeOptions: Array<{ label: string; value: VendorTenantTypeFilter }> = [
+  { label: "Semua Tenant", value: "all" },
+  { label: "Koperasi", value: "koperasi" },
+  { label: "BUMDes", value: "bumdes" },
+  { label: "UMKM", value: "umkm" },
+];
+
+const subscriptionStatusOptions: Array<{
+  label: string;
+  value: VendorSubscriptionStatusFilter;
+}> = [
+  { label: "Semua Status", value: "all" },
+  { label: "Aktif", value: "active" },
+  { label: "Masa Uji Coba", value: "trial" },
+  { label: "Dibatalkan", value: "cancelled" },
+  { label: "Kedaluwarsa", value: "expired" },
+];
+
+export function VendorDashboardGlobalFilters() {
+  const {
+    filters,
+    setDateRange,
+    setTenantType,
+    setSubscriptionStatus,
+    reset,
+  } = useVendorDashboardFilters();
+
+  return (
+    <Card>
+      <CardContent className="flex flex-col gap-4 py-4 md:flex-row md:items-end md:justify-between">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end">
+          <DateRangePicker
+            label="Rentang Tanggal"
+            value={{
+              start: filters.dateRange?.from,
+              end: filters.dateRange?.to,
+            }}
+            onChange={(_, __, dates) => {
+              setDateRange(
+                dates?.start || dates?.end
+                  ? { from: dates?.start, to: dates?.end }
+                  : null,
+              );
+            }}
+            triggerClassName="sm:w-[260px]"
+          />
+
+          <div className="space-y-2">
+            <span className="text-sm font-medium text-muted-foreground">
+              Tipe Tenant
+            </span>
+            <Select
+              value={filters.tenantType}
+              onValueChange={(value: VendorTenantTypeFilter) => setTenantType(value)}
+            >
+              <SelectTrigger className="w-[200px]">
+                <SelectValue placeholder="Pilih tipe tenant" />
+              </SelectTrigger>
+              <SelectContent>
+                {tenantTypeOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <span className="text-sm font-medium text-muted-foreground">
+              Status Langganan
+            </span>
+            <Select
+              value={filters.subscriptionStatus}
+              onValueChange={(value: VendorSubscriptionStatusFilter) =>
+                setSubscriptionStatus(value)
+              }
+            >
+              <SelectTrigger className="w-[200px]">
+                <SelectValue placeholder="Pilih status" />
+              </SelectTrigger>
+              <SelectContent>
+                {subscriptionStatusOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => reset()}
+            className="gap-2"
+          >
+            <RefreshCcw className="h-4 w-4" /> Reset
+          </Button>
+          <div className="rounded-md border border-dashed px-3 py-2 text-sm text-muted-foreground">
+            Filter diterapkan secara global untuk semua widget
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/feature/vendor/dashboard/vendor-dashboard-kpi-grid.tsx
+++ b/src/components/feature/vendor/dashboard/vendor-dashboard-kpi-grid.tsx
@@ -1,0 +1,109 @@
+/** @format */
+
+"use client";
+
+import { Users, Ticket, Target, PackageSearch } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useVendorDashboardData } from "./vendor-dashboard-data-provider";
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat("id-ID").format(value);
+}
+
+export function VendorDashboardKpiGrid() {
+  const {
+    totalActiveClients,
+    openTickets,
+    mostActiveClient,
+    productWithMostTickets,
+    isLoading,
+    data,
+  } = useVendorDashboardData();
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Total Klien Aktif</CardTitle>
+          <Users className="h-4 w-4 text-muted-foreground" />
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <Skeleton className="h-8 w-24" />
+          ) : (
+            <div className="text-2xl font-semibold">
+              {formatNumber(totalActiveClients)}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Tiket Terbuka</CardTitle>
+          <Ticket className="h-4 w-4 text-muted-foreground" />
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <Skeleton className="h-8 w-20" />
+          ) : (
+            <div className="text-2xl font-semibold">{formatNumber(openTickets)}</div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Klien Paling Aktif</CardTitle>
+          <Target className="h-4 w-4 text-muted-foreground" />
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {isLoading ? (
+            <Skeleton className="h-5 w-36" />
+          ) : mostActiveClient ? (
+            <div className="space-y-1">
+              <p className="font-medium leading-none">{mostActiveClient.name}</p>
+              <p className="text-sm text-muted-foreground">
+                {formatNumber(mostActiveClient.ticket_count)} tiket dalam 30 hari terakhir
+              </p>
+            </div>
+          ) : data ? (
+            <p className="text-sm text-muted-foreground">
+              Belum ada aktivitas tiket yang menonjol.
+            </p>
+          ) : (
+            <Skeleton className="h-5 w-24" />
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Produk dengan Tiket Terbanyak</CardTitle>
+          <PackageSearch className="h-4 w-4 text-muted-foreground" />
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {isLoading ? (
+            <Skeleton className="h-5 w-32" />
+          ) : productWithMostTickets ? (
+            <div className="space-y-1">
+              <p className="font-medium leading-none">
+                {productWithMostTickets.name}
+              </p>
+              <p className="text-sm text-muted-foreground">
+                {formatNumber(productWithMostTickets.ticket_count)} tiket aktif
+              </p>
+            </div>
+          ) : data ? (
+            <p className="text-sm text-muted-foreground">
+              Tidak ada produk dengan eskalasi tinggi saat ini.
+            </p>
+          ) : (
+            <Skeleton className="h-5 w-24" />
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/feature/vendor/dashboard/vendor-dashboard-ticket-insights.tsx
+++ b/src/components/feature/vendor/dashboard/vendor-dashboard-ticket-insights.tsx
@@ -1,0 +1,101 @@
+/** @format */
+
+"use client";
+
+import type { ReactNode } from "react";
+import { AlertCircle, Ticket, UsersRound, PackageSearch } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useVendorDashboardData } from "./vendor-dashboard-data-provider";
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat("id-ID").format(value);
+}
+
+export function VendorDashboardTicketInsights() {
+  const {
+    openTickets,
+    mostActiveClient,
+    productWithMostTickets,
+    isLoading,
+    data,
+  } = useVendorDashboardData();
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle>Insight Dukungan</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center justify-between rounded-lg border px-4 py-3">
+          <div className="space-y-1 text-sm">
+            <p className="font-medium flex items-center gap-2">
+              <Ticket className="h-4 w-4" /> Tiket Terbuka
+            </p>
+            <p className="text-muted-foreground">
+              Total tiket yang menunggu penanganan
+            </p>
+          </div>
+          {isLoading ? (
+            <Skeleton className="h-8 w-16" />
+          ) : (
+            <Badge variant="outline" className="text-base font-semibold">
+              {formatNumber(openTickets)}
+            </Badge>
+          )}
+        </div>
+
+        <div className="grid gap-3">
+          <InsightItem
+            icon={<UsersRound className="h-4 w-4" />}
+            title="Klien Paling Aktif"
+            description={mostActiveClient?.name ?? "Belum ada aktivitas yang menonjol"}
+            metric={mostActiveClient?.ticket_count}
+            loading={isLoading && !data}
+          />
+          <InsightItem
+            icon={<PackageSearch className="h-4 w-4" />}
+            title="Produk dengan Eskalasi Tertinggi"
+            description={
+              productWithMostTickets?.name ?? "Tidak ada produk yang mendominasi tiket"
+            }
+            metric={productWithMostTickets?.ticket_count}
+            loading={isLoading && !data}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+type InsightItemProps = {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  metric?: number;
+  loading?: boolean;
+};
+
+function InsightItem({ icon, title, description, metric, loading }: InsightItemProps) {
+  return (
+    <div className="flex items-start gap-3 rounded-lg border px-3 py-3">
+      <span className="flex h-9 w-9 items-center justify-center rounded-md bg-muted text-muted-foreground">
+        {icon}
+      </span>
+      <div className="flex-1 space-y-1 text-sm">
+        <p className="font-medium leading-none">{title}</p>
+        <p className="text-muted-foreground">{description}</p>
+      </div>
+      <div className="min-w-[72px] text-right text-sm font-semibold text-muted-foreground">
+        {loading ? (
+          <Skeleton className="h-5 w-full" />
+        ) : typeof metric === "number" ? (
+          formatNumber(metric)
+        ) : (
+          <AlertCircle className="mx-auto h-4 w-4" />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/feature/vendor/dashboard/vendor-dashboard-tier-breakdown.tsx
+++ b/src/components/feature/vendor/dashboard/vendor-dashboard-tier-breakdown.tsx
@@ -1,0 +1,54 @@
+/** @format */
+
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import { useVendorDashboardData } from "./vendor-dashboard-data-provider";
+
+function formatTierLabel(tier: string) {
+  return tier
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export function VendorDashboardTierBreakdown() {
+  const { tiers, isLoading } = useVendorDashboardData();
+  const formatter = new Intl.NumberFormat("id-ID");
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle>Distribusi Klien per Tier</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {isLoading ? (
+          <div className="space-y-2">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <Skeleton key={index} className="h-10 w-full" />
+            ))}
+          </div>
+        ) : tiers.length ? (
+          <div className="space-y-2">
+            {tiers.map((tier) => (
+              <div
+                key={tier.tier}
+                className="flex items-center justify-between rounded-lg border px-3 py-2 text-sm"
+              >
+                <span className="font-medium">{formatTierLabel(tier.tier)}</span>
+                <Badge variant="secondary" className="font-semibold">
+                  {formatter.format(tier.active_clients ?? 0)}
+                </Badge>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+            Data distribusi klien belum tersedia.
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/feature/vendor/dashboard/vendor-dashboard-upcoming-widgets.tsx
+++ b/src/components/feature/vendor/dashboard/vendor-dashboard-upcoming-widgets.tsx
@@ -1,0 +1,27 @@
+/** @format */
+
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function VendorDashboardUpcomingWidgets() {
+  return (
+    <Card className="h-full">
+      <CardHeader className="pb-2">
+        <CardTitle>Widget Mendatang</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm text-muted-foreground">
+        <p>
+          Ruang kosong untuk widget lanjutan seperti performa produk, pendapatan, atau
+          notifikasi penting lainnya.
+        </p>
+        <div className="space-y-2">
+          <Skeleton className="h-3 w-5/6" />
+          <Skeleton className="h-3 w-2/3" />
+          <Skeleton className="h-3 w-4/5" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- rebuild the vendor dashboard route with breadcrumb header and three-row layout scaffolding that matches the dashboard design system
- add a global filter context and SWR-powered data provider that exposes KPI metrics from GET /api/vendor/dashboard to downstream widgets
- implement reusable widgets for KPI cards, tier distribution, support insights, and placeholder sections for upcoming content

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0d57c187c8322830af3a35e79232c