### PR TITLE
Add vendor dashboard billing overview and revenue analytics

### DIFF
--- a/src/app/(main)/vendor/dashboard/page.tsx
+++ b/src/app/(main)/vendor/dashboard/page.tsx
@@ -3,8 +3,6 @@
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
 import { VendorDashboardFilterProvider } from "@/components/feature/vendor/dashboard/vendor-dashboard-filter-context";
 import { VendorDashboardDataProvider, useVendorDashboardData } from "@/components/feature/vendor/dashboard/vendor-dashboard-data-provider";
 import { VendorDashboardGlobalFilters } from "@/components/feature/vendor/dashboard/vendor-dashboard-filters";
@@ -12,6 +10,9 @@ import { VendorDashboardKpiGrid } from "@/components/feature/vendor/dashboard/ve
 import { VendorDashboardTierBreakdown } from "@/components/feature/vendor/dashboard/vendor-dashboard-tier-breakdown";
 import { VendorDashboardTicketInsights } from "@/components/feature/vendor/dashboard/vendor-dashboard-ticket-insights";
 import { VendorDashboardUpcomingWidgets } from "@/components/feature/vendor/dashboard/vendor-dashboard-upcoming-widgets";
+import { VendorDashboardBillingOverview } from "@/components/feature/vendor/dashboard/vendor-dashboard-billing-overview";
+import { VendorDashboardRecurringRevenue } from "@/components/feature/vendor/dashboard/vendor-dashboard-recurring-revenue";
+import { VendorDashboardInvoiceWatchlist } from "@/components/feature/vendor/dashboard/vendor-dashboard-invoice-watchlist";
 
 export default function VendorDashboardPage() {
   return (
@@ -79,34 +80,18 @@ function VendorDashboardPageShell() {
           <VendorDashboardTicketInsights />
         </section>
 
+        <section className="grid gap-6 xl:grid-cols-[2fr_1.2fr]">
+          <VendorDashboardRecurringRevenue />
+          <VendorDashboardBillingOverview />
+        </section>
+
         <section className="grid gap-6 xl:grid-cols-3">
+          <div className="xl:col-span-2">
+            <VendorDashboardInvoiceWatchlist />
+          </div>
           <VendorDashboardUpcomingWidgets />
-          <VendorDashboardPlaceholderCard title="Integrasi Billing" />
-          <VendorDashboardPlaceholderCard title="Aktivitas Produk" />
         </section>
       </div>
     </div>
-  );
-}
-
-type PlaceholderCardProps = {
-  title: string;
-};
-
-function VendorDashboardPlaceholderCard({ title }: PlaceholderCardProps) {
-  return (
-    <Card className="h-full">
-      <CardHeader className="pb-2">
-        <CardTitle>{title}</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-3 text-sm text-muted-foreground">
-        <p>Widget akan ditempatkan di sini setelah integrasi backend tersedia.</p>
-        <div className="space-y-2">
-          <Skeleton className="h-3 w-full" />
-          <Skeleton className="h-3 w-2/3" />
-          <Skeleton className="h-3 w-3/4" />
-        </div>
-      </CardContent>
-    </Card>
   );
 }

--- a/src/components/feature/vendor/dashboard/vendor-dashboard-billing-overview.tsx
+++ b/src/components/feature/vendor/dashboard/vendor-dashboard-billing-overview.tsx
@@ -1,0 +1,195 @@
+/** @format */
+
+"use client";
+
+import { Pie, PieChart, Cell } from "recharts";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { useVendorBillingReport } from "./vendor-dashboard-hooks";
+
+const currencyFormatter = new Intl.NumberFormat("id-ID", {
+  style: "currency",
+  currency: "IDR",
+  maximumFractionDigits: 0,
+});
+
+const chartConfig = {
+  paid: {
+    label: "Dibayar",
+    color: "hsl(var(--chart-1))",
+  },
+  pending: {
+    label: "Belum Dibayar",
+    color: "hsl(var(--chart-2))",
+  },
+  overdue: {
+    label: "Terlambat",
+    color: "hsl(var(--chart-3))",
+  },
+} satisfies ChartConfig;
+
+export function VendorDashboardBillingOverview() {
+  const { data, error, isLoading, isValidating, mutate } = useVendorBillingReport();
+
+  const loading = isLoading && !data;
+
+  if (error) {
+    return (
+      <Card className="h-full">
+        <CardHeader className="pb-2">
+          <CardTitle>Ikhtisar Billing</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Alert variant="destructive">
+            <AlertDescription className="flex flex-col gap-3">
+              <span>
+                Tidak dapat memuat ringkasan billing saat ini. Silakan coba lagi.
+              </span>
+              <Button size="sm" variant="outline" onClick={() => mutate()}>
+                Muat ulang
+              </Button>
+            </AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const totalRevenue =
+    (data?.revenue?.subscription ?? 0) + (data?.revenue?.outstanding ?? 0);
+  const totalInvoices = data?.total_invoices ?? 0;
+  const chartData = (
+    [
+      {
+        name: chartConfig.paid.label,
+        value: data?.status_detail?.paid ?? 0,
+        key: "paid" as const,
+      },
+      {
+        name: chartConfig.pending.label,
+        value: data?.status_detail?.pending ?? 0,
+        key: "pending" as const,
+      },
+      {
+        name: chartConfig.overdue.label,
+        value: data?.status_detail?.overdue ?? 0,
+        key: "overdue" as const,
+      },
+    ]
+  ).filter((item) => item.value > 0);
+
+  return (
+    <Card className="h-full">
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle>Ikhtisar Billing</CardTitle>
+          {isValidating ? (
+            <span className="text-xs text-muted-foreground">Memuat...</span>
+          ) : null}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {loading ? (
+          <div className="grid gap-6 lg:grid-cols-2 lg:items-center">
+            <div className="space-y-3">
+              <Skeleton className="h-6 w-36" />
+              <Skeleton className="h-10 w-48" />
+              <div className="grid gap-3 sm:grid-cols-2">
+                <Skeleton className="h-16 w-full" />
+                <Skeleton className="h-16 w-full" />
+              </div>
+            </div>
+            <Skeleton className="aspect-square w-full max-w-[280px] justify-self-center rounded-full" />
+          </div>
+        ) : (
+          <div className="grid gap-6 lg:grid-cols-2 lg:items-center">
+            <div className="space-y-4">
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Pendapatan Bulan Ini
+                </p>
+                <p className="text-3xl font-semibold">
+                  {currencyFormatter.format(totalRevenue)}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Termasuk tagihan berlangganan dan outstanding dalam rentang filter.
+                </p>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="rounded-lg border p-3">
+                  <p className="text-xs text-muted-foreground">Tagihan Aktif</p>
+                  <p className="text-lg font-semibold">{totalInvoices}</p>
+                </div>
+                <div className="rounded-lg border p-3">
+                  <p className="text-xs text-muted-foreground">Pendapatan Tertagih</p>
+                  <p className="text-lg font-semibold">
+                    {currencyFormatter.format(data?.revenue?.subscription ?? 0)}
+                  </p>
+                </div>
+                <div className="rounded-lg border p-3">
+                  <p className="text-xs text-muted-foreground">Outstanding</p>
+                  <p className="text-lg font-semibold">
+                    {currencyFormatter.format(data?.revenue?.outstanding ?? 0)}
+                  </p>
+                </div>
+                <div className="rounded-lg border p-3">
+                  <p className="text-xs text-muted-foreground">Invoice Terlambat</p>
+                  <p className="text-lg font-semibold">
+                    {data?.status_detail?.overdue ?? 0}
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex flex-col items-center gap-4">
+              {chartData.length ? (
+                <ChartContainer
+                  config={chartConfig}
+                  className="mx-auto h-[240px] w-full max-w-[320px]"
+                >
+                  <PieChart>
+                    <Pie data={chartData} dataKey="value" nameKey="name" innerRadius={60} outerRadius={100}>
+                      {chartData.map((entry) => (
+                        <Cell
+                          key={entry.key}
+                          fill={`var(--color-${entry.key})`}
+                          strokeWidth={2}
+                        />
+                      ))}
+                    </Pie>
+                    <ChartTooltip
+                      cursor={false}
+                      content={
+                        <ChartTooltipContent
+                          formatter={(value, name) => [String(value), name]}
+                        />
+                      }
+                    />
+                  </PieChart>
+                </ChartContainer>
+              ) : (
+                <div className="flex h-[240px] w-full flex-col items-center justify-center gap-2 rounded-lg border text-sm text-muted-foreground">
+                  <span>Tidak ada data status invoice pada rentang ini.</span>
+                </div>
+              )}
+              <Button size="sm" variant="outline" onClick={() => mutate()}>
+                Segarkan Data
+              </Button>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/src/components/feature/vendor/dashboard/vendor-dashboard-hooks.ts
+++ b/src/components/feature/vendor/dashboard/vendor-dashboard-hooks.ts
@@ -1,0 +1,47 @@
+/** @format */
+
+"use client";
+
+import { useMemo } from "react";
+import useSWR from "swr";
+import { format as formatDate } from "date-fns";
+
+import { ensureSuccess } from "@/lib/api";
+import { getBillingReport } from "@/services/api";
+import type { BillingReportResponse } from "@/types/api";
+
+import { useVendorDashboardFilters } from "./vendor-dashboard-filter-context";
+
+export function useVendorDashboardDateParams() {
+  const { filters } = useVendorDashboardFilters();
+
+  return useMemo(() => {
+    const { dateRange } = filters;
+    const start = dateRange?.from ? formatDate(dateRange.from, "yyyy-MM-dd") : undefined;
+    const end = dateRange?.to ? formatDate(dateRange.to, "yyyy-MM-dd") : undefined;
+
+    return {
+      hasRange: Boolean(start || end),
+      start,
+      end,
+    } as const;
+  }, [filters]);
+}
+
+export function useVendorBillingReport() {
+  const { start, end } = useVendorDashboardDateParams();
+
+  const paramsKey = JSON.stringify({ start, end });
+
+  const swr = useSWR<BillingReportResponse>(
+    ["vendor-dashboard", "billing-report", paramsKey],
+    async () => ensureSuccess(await getBillingReport({ start, end })),
+    {
+      keepPreviousData: true,
+      revalidateOnFocus: false,
+    },
+  );
+
+  return swr;
+}
+

--- a/src/components/feature/vendor/dashboard/vendor-dashboard-invoice-watchlist.tsx
+++ b/src/components/feature/vendor/dashboard/vendor-dashboard-invoice-watchlist.tsx
@@ -1,0 +1,235 @@
+/** @format */
+
+"use client";
+
+import { useMemo } from "react";
+import useSWR from "swr";
+import Link from "next/link";
+import { format, differenceInCalendarDays } from "date-fns";
+
+import { ensureSuccess } from "@/lib/api";
+import { getVendorInvoice } from "@/services/api";
+import type { Invoice } from "@/types/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useVendorBillingReport } from "./vendor-dashboard-hooks";
+
+const currencyFormatter = new Intl.NumberFormat("id-ID", {
+  style: "currency",
+  currency: "IDR",
+  maximumFractionDigits: 0,
+});
+
+export function VendorDashboardInvoiceWatchlist() {
+  const {
+    data: billing,
+    error: billingError,
+    isLoading,
+    isValidating,
+    mutate,
+  } = useVendorBillingReport();
+
+  const overdueInvoices = useMemo(
+    () => billing?.overdue_invoices ?? [],
+    [billing?.overdue_invoices],
+  );
+  const invoiceIds = useMemo(
+    () => overdueInvoices.map((invoice) => invoice.id),
+    [overdueInvoices],
+  );
+
+  const {
+    data: invoiceDetails = [],
+    error: invoiceError,
+    isLoading: detailsLoading,
+    mutate: mutateInvoiceDetails,
+  } = useSWR<Invoice[]>(
+    invoiceIds.length
+      ? ["vendor-dashboard", "invoice-details", invoiceIds.join(",")]
+      : null,
+    async () => {
+      const responses = await Promise.all(
+        invoiceIds.map(async (id) => ensureSuccess(await getVendorInvoice(id))),
+      );
+      return responses;
+    },
+    {
+      revalidateOnFocus: false,
+    },
+  );
+
+  const detailMap = useMemo(() => {
+    const map = new Map<number, Invoice>();
+    for (const detail of invoiceDetails ?? []) {
+      if (detail?.id) map.set(detail.id, detail);
+    }
+    return map;
+  }, [invoiceDetails]);
+
+  if (billingError) {
+    return (
+      <Card className="h-full">
+        <CardHeader className="pb-2">
+          <CardTitle>Watchlist Invoice</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Alert variant="destructive">
+            <AlertDescription className="flex flex-col gap-3">
+              <span>Tidak dapat mengambil daftar invoice yang terlambat.</span>
+              <Button size="sm" variant="outline" onClick={() => mutate()}>
+                Coba lagi
+              </Button>
+            </AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const loading = isLoading && !billing;
+
+  return (
+    <Card className="h-full">
+      <CardHeader className="flex flex-col gap-2 pb-0 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <CardTitle>Watchlist Invoice</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Monitor invoice yang melewati jatuh tempo dan tindak lanjuti segera.
+          </p>
+        </div>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          {isValidating ? <span>Memperbarui data…</span> : null}
+          {invoiceError ? (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                void mutate();
+                void mutateInvoiceDetails();
+              }}
+            >
+              Muat ulang
+            </Button>
+          ) : null}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4 pt-4">
+        {invoiceError ? (
+          <Alert variant="destructive">
+            <AlertDescription>
+              Detail invoice tidak dapat dimuat. Anda tetap dapat melihat ringkasan dasar.
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        {loading ? (
+          <div className="space-y-3">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <Skeleton key={index} className="h-14 w-full" />
+            ))}
+          </div>
+        ) : overdueInvoices.length ? (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Invoice</TableHead>
+                  <TableHead>Tenant</TableHead>
+                  <TableHead className="text-right">Total</TableHead>
+                  <TableHead>Jatuh Tempo</TableHead>
+                  <TableHead>Hari Terlambat</TableHead>
+                  <TableHead>Aksi</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {overdueInvoices.map((invoice) => {
+                  const detail = detailMap.get(invoice.id);
+                  const dueDate = invoice.due_date
+                    ? new Date(invoice.due_date)
+                    : detail?.due_date
+                    ? new Date(detail.due_date)
+                    : null;
+                  const formattedDueDate = dueDate
+                    ? format(dueDate, "d MMM yyyy")
+                    : "-";
+                  const overdueDays = dueDate
+                    ? Math.max(0, differenceInCalendarDays(new Date(), dueDate))
+                    : 0;
+                  const tenantId = detail?.tenant_id ?? invoice.tenant_id;
+                  const tenantLabel = `Tenant #${tenantId}`;
+                  const amount = detail?.total ?? invoice.total ?? 0;
+
+                  return (
+                    <TableRow key={invoice.id}>
+                      <TableCell className="font-medium">
+                        <div className="flex flex-col">
+                          <span>{invoice.number}</span>
+                          {detail?.subscription?.plan?.name ? (
+                            <span className="text-xs text-muted-foreground">
+                              {detail.subscription.plan.name}
+                            </span>
+                          ) : null}
+                        </div>
+                      </TableCell>
+                      <TableCell>{tenantLabel}</TableCell>
+                      <TableCell className="text-right">
+                        {currencyFormatter.format(amount)}
+                      </TableCell>
+                      <TableCell>{formattedDueDate}</TableCell>
+                      <TableCell>
+                        <Badge variant="destructive">{overdueDays} hari</Badge>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-wrap gap-2">
+                          <Button asChild size="sm" variant="secondary">
+                            <Link href={`/vendor/invoices?highlight=${invoice.id}`}>
+                              Lihat Invoice
+                            </Link>
+                          </Button>
+                          <Button
+                            asChild
+                            size="sm"
+                            variant="outline"
+                          >
+                            <a
+                              href={`mailto:?subject=Follow up Invoice ${invoice.number}`}
+                              rel="noreferrer"
+                            >
+                              Hubungi
+                            </a>
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        ) : detailsLoading ? (
+          <div className="space-y-3">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <Skeleton key={index} className="h-14 w-full" />
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-lg border p-6 text-center text-sm text-muted-foreground">
+            Semua invoice berada dalam kondisi baik. Tidak ada watchlist untuk ditampilkan.
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/src/components/feature/vendor/dashboard/vendor-dashboard-recurring-revenue.tsx
+++ b/src/components/feature/vendor/dashboard/vendor-dashboard-recurring-revenue.tsx
@@ -1,0 +1,205 @@
+/** @format */
+
+"use client";
+
+import { useState, useMemo } from "react";
+import useSWR from "swr";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { ensureSuccess } from "@/lib/api";
+import { getVendorFinancialReport } from "@/services/api";
+import type { VendorFinancialReport } from "@/types/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useVendorDashboardDateParams } from "./vendor-dashboard-hooks";
+
+const currencyFormatter = new Intl.NumberFormat("id-ID", {
+  style: "currency",
+  currency: "IDR",
+  maximumFractionDigits: 0,
+});
+
+const chartConfig = {
+  mrr: {
+    label: "MRR",
+    color: "hsl(var(--chart-1))",
+  },
+  arr: {
+    label: "ARR",
+    color: "hsl(var(--chart-2))",
+  },
+} satisfies ChartConfig;
+
+const groupByOptions = [
+  { label: "Bulanan", value: "month" },
+  { label: "Kuartal", value: "quarter" },
+];
+
+export function VendorDashboardRecurringRevenue() {
+  const { start, end } = useVendorDashboardDateParams();
+  const [groupBy, setGroupBy] = useState<string>("month");
+
+  const paramsKey = useMemo(
+    () => JSON.stringify({ start, end, groupBy }),
+    [start, end, groupBy],
+  );
+
+  const { data, error, isLoading, isValidating, mutate } = useSWR<VendorFinancialReport>(
+    ["vendor-dashboard", "financial-report", paramsKey],
+    async () =>
+      ensureSuccess(
+        await getVendorFinancialReport({
+          start_date: start,
+          end_date: end,
+          group_by: groupBy,
+        }),
+      ),
+    {
+      keepPreviousData: true,
+      revalidateOnFocus: false,
+    },
+  );
+
+  const loading = isLoading && !data;
+
+  if (error) {
+    return (
+      <Card className="h-full">
+        <CardHeader className="pb-2">
+          <CardTitle>MRR & ARR</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Alert variant="destructive">
+            <AlertDescription className="flex flex-col gap-3">
+              <span>Grafik pendapatan berulang tidak dapat dimuat.</span>
+              <Button size="sm" variant="outline" onClick={() => mutate()}>
+                Coba lagi
+              </Button>
+            </AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const series = data?.series ?? [];
+  const totals = data?.totals ?? { mrr: 0, arr: 0 };
+
+  return (
+    <Card className="h-full">
+      <CardHeader className="flex flex-col gap-3 pb-0 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <CardTitle>MRR & ARR</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Tren pendapatan berulang berdasarkan rentang tanggal terpilih.
+          </p>
+        </div>
+        <Select value={groupBy} onValueChange={(value) => setGroupBy(value)}>
+          <SelectTrigger className="w-[160px]">
+            <SelectValue placeholder="Kelompokkan" />
+          </SelectTrigger>
+          <SelectContent>
+            {groupByOptions.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </CardHeader>
+      <CardContent className="space-y-4 pt-4">
+        {isValidating ? (
+          <p className="text-xs text-muted-foreground">Memperbarui data…</p>
+        ) : null}
+
+        {loading ? (
+          <Skeleton className="h-[260px] w-full" />
+        ) : series.length ? (
+          <>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="rounded-lg border p-3">
+                <p className="text-xs text-muted-foreground">Total MRR</p>
+                <p className="text-lg font-semibold">
+                  {currencyFormatter.format(totals.mrr ?? 0)}
+                </p>
+              </div>
+              <div className="rounded-lg border p-3">
+                <p className="text-xs text-muted-foreground">Total ARR</p>
+                <p className="text-lg font-semibold">
+                  {currencyFormatter.format(totals.arr ?? 0)}
+                </p>
+              </div>
+            </div>
+
+            <ChartContainer config={chartConfig} className="h-[260px] w-full">
+              <AreaChart data={series} margin={{ left: 12, right: 12 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="period" tickLine={false} axisLine={false} />
+                <YAxis
+                  tickFormatter={(value) => currencyFormatter.format(value).replace(/,00$/, "")}
+                  width={90}
+                />
+                <ChartTooltip
+                  content={
+                    <ChartTooltipContent
+                      formatter={(value, name) => [
+                        currencyFormatter.format(Number(value)),
+                        name,
+                      ]}
+                    />
+                  }
+                />
+                <Area
+                  type="monotone"
+                  dataKey="mrr"
+                  stroke="var(--color-mrr)"
+                  fill="var(--color-mrr)"
+                  fillOpacity={0.2}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="arr"
+                  stroke="var(--color-arr)"
+                  fill="var(--color-arr)"
+                  fillOpacity={0.2}
+                />
+              </AreaChart>
+            </ChartContainer>
+          </>
+        ) : (
+          <div className="flex h-[260px] w-full flex-col items-center justify-center gap-2 rounded-lg border text-sm text-muted-foreground">
+            Tidak ada data pendapatan berulang untuk rentang ini.
+          </div>
+        )}
+
+        <div className="flex justify-end">
+          <Button size="sm" variant="outline" onClick={() => mutate()}>
+            Segarkan Data
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/src/types/api/reporting.ts
+++ b/src/types/api/reporting.ts
@@ -119,7 +119,19 @@ export type ReportExportMeta = {
   created_at: Rfc3339String;
 };
 
-export type VendorFinancialReport = Record<string, unknown>;
+export type VendorRecurringRevenuePoint = {
+  period: string;
+  mrr: number;
+  arr: number;
+};
+
+export type VendorFinancialReport = {
+  totals: {
+    mrr: number;
+    arr: number;
+  };
+  series: VendorRecurringRevenuePoint[];
+};
 export type VendorUsageReport = Record<string, unknown>;
 
 export type GetFinanceReportResponse = ApiResponse<FinanceReportResponse>;


### PR DESCRIPTION
## Summary
- integrate the billing report feed into the vendor dashboard with KPI tiles and donut chart for invoice status
- add a recurring revenue chart that calls the vendor financial report with adjustable month/quarter grouping tied to global filters
- surface an invoice watchlist that hydrates overdue invoices with detail fetches and provides follow-up CTAs, plus shareable hooks and typing updates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0e680b5288322b458dcaf0968804b