### PR TITLE
feat: add tenant engagement analytics widgets

### DIFF
--- a/src/app/(main)/vendor/clients/clients-list-client.tsx
+++ b/src/app/(main)/vendor/clients/clients-list-client.tsx
@@ -47,8 +47,16 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { Client, TenantUser } from "@/types/api";
 import { useConfirm } from "@/hooks/use-confirm";
 
-export function ClientsListClient({ rows }: { rows: Client[] }) {
-  const [selectedId, setSelectedId] = useState<Client["id"] | null>(null);
+export function ClientsListClient({
+  rows,
+  initialSelectedId,
+}: {
+  rows: Client[];
+  initialSelectedId?: number | null;
+}) {
+  const [selectedId, setSelectedId] = useState<Client["id"] | null>(
+    initialSelectedId ?? null,
+  );
   const [q, setQ] = useState("");
   const listParams = useMemo(
     () => ({ limit: rows?.length || 10 }),
@@ -69,6 +77,11 @@ export function ClientsListClient({ rows }: { rows: Client[] }) {
       (t.type || "").toLowerCase().includes(query)
     );
   });
+  useEffect(() => {
+    if (initialSelectedId != null) {
+      setSelectedId(initialSelectedId);
+    }
+  }, [initialSelectedId]);
   const selected = useMemo(() => {
     if (selectedId == null) return null;
     return (

--- a/src/app/(main)/vendor/clients/page.tsx
+++ b/src/app/(main)/vendor/clients/page.tsx
@@ -10,8 +10,17 @@ import type { Client } from "@/types/api";
 export const dynamic = "force-dynamic";
 
 // TODO integrate API: extend detail modal with full client details via API
-export default async function ClientsPage() {
-  const clients = await listClients({ limit: 10 });
+export default async function ClientsPage({
+  searchParams,
+}: {
+  searchParams?: { tenantId?: string | string[] };
+}) {
+  const tenantIdParam = Array.isArray(searchParams?.tenantId)
+    ? searchParams?.tenantId[0]
+    : searchParams?.tenantId;
+  const initialSelectedId = tenantIdParam ? Number(tenantIdParam) : null;
+  const limit = initialSelectedId ? 200 : 10;
+  const clients = await listClients({ limit });
 
   return (
     <div className="space-y-6">
@@ -29,7 +38,10 @@ export default async function ClientsPage() {
         </CardHeader>
         <CardContent>
           {clients?.data?.length ? (
-            <ClientsListClient rows={clients.data as Client[]} />
+            <ClientsListClient
+              rows={clients.data as Client[]}
+              initialSelectedId={initialSelectedId}
+            />
           ) : (
             <div className="text-muted-foreground text-sm italic py-4">
               No clients found.

--- a/src/app/(main)/vendor/dashboard/page.tsx
+++ b/src/app/(main)/vendor/dashboard/page.tsx
@@ -13,6 +13,9 @@ import { VendorDashboardUpcomingWidgets } from "@/components/feature/vendor/dash
 import { VendorDashboardBillingOverview } from "@/components/feature/vendor/dashboard/vendor-dashboard-billing-overview";
 import { VendorDashboardRecurringRevenue } from "@/components/feature/vendor/dashboard/vendor-dashboard-recurring-revenue";
 import { VendorDashboardInvoiceWatchlist } from "@/components/feature/vendor/dashboard/vendor-dashboard-invoice-watchlist";
+import { VendorDashboardLoginLeaderboard } from "@/components/feature/vendor/dashboard/vendor-dashboard-login-leaderboard";
+import { VendorDashboardModuleAdoption } from "@/components/feature/vendor/dashboard/vendor-dashboard-module-adoption";
+import { VendorDashboardInsightsHighlights } from "@/components/feature/vendor/dashboard/vendor-dashboard-insights-highlights";
 
 export default function VendorDashboardPage() {
   return (
@@ -83,6 +86,14 @@ function VendorDashboardPageShell() {
         <section className="grid gap-6 xl:grid-cols-[2fr_1.2fr]">
           <VendorDashboardRecurringRevenue />
           <VendorDashboardBillingOverview />
+        </section>
+
+        <section className="grid gap-6 2xl:grid-cols-[2fr_1fr]">
+          <VendorDashboardLoginLeaderboard />
+          <div className="space-y-6">
+            <VendorDashboardInsightsHighlights />
+            <VendorDashboardModuleAdoption />
+          </div>
         </section>
 
         <section className="grid gap-6 xl:grid-cols-3">

--- a/src/components/feature/vendor/dashboard/vendor-dashboard-date-utils.ts
+++ b/src/components/feature/vendor/dashboard/vendor-dashboard-date-utils.ts
@@ -1,0 +1,90 @@
+/** @format */
+
+"use client";
+
+import type { DateRange } from "react-day-picker";
+
+export type VendorDashboardResolvedRanges = {
+  current: { start: Date; end: Date };
+  previous: { start: Date; end: Date };
+};
+
+export function resolveDashboardDateRanges(
+  range: DateRange | null,
+): VendorDashboardResolvedRanges {
+  const today = new Date();
+  const start = range?.from ? new Date(range.from) : undefined;
+  const end = range?.to ? new Date(range.to) : range?.from ? new Date(range.from) : today;
+
+  const normalizedEnd = normalizeEndOfDay(end);
+  const normalizedStart = normalizeStartOfDay(start ?? subtractDays(normalizedEnd, 29));
+
+  if (normalizedStart > normalizedEnd) {
+    return resolveDashboardDateRanges({ from: normalizedEnd, to: normalizedStart });
+  }
+
+  const durationMs = normalizedEnd.getTime() - normalizedStart.getTime();
+  const previousEnd = normalizeEndOfDay(new Date(normalizedStart.getTime() - 1));
+  const previousStart = normalizeStartOfDay(
+    new Date(previousEnd.getTime() - durationMs),
+  );
+
+  return {
+    current: { start: normalizedStart, end: normalizedEnd },
+    previous: { start: previousStart, end: previousEnd },
+  };
+}
+
+export function buildRangeCacheKey(range: VendorDashboardResolvedRanges) {
+  return [
+    range.current.start.toISOString(),
+    range.current.end.toISOString(),
+    range.previous.start.toISOString(),
+    range.previous.end.toISOString(),
+  ].join("|");
+}
+
+export function isDateWithinRange(date: Date | string | number, start: Date, end: Date) {
+  const value = new Date(date);
+  if (Number.isNaN(value.getTime())) return false;
+  return value.getTime() >= start.getTime() && value.getTime() <= end.getTime();
+}
+
+export function intervalOverlapsRange(
+  intervalStart: Date | string | number | null | undefined,
+  intervalEnd: Date | string | number | null | undefined,
+  rangeStart: Date,
+  rangeEnd: Date,
+) {
+  const start = intervalStart ? new Date(intervalStart) : null;
+  const end = intervalEnd ? new Date(intervalEnd) : null;
+
+  if (start && Number.isNaN(start.getTime())) return false;
+  if (end && Number.isNaN(end.getTime())) return false;
+
+  const effectiveStart = start ?? new Date(0);
+  const effectiveEnd = end ?? new Date("9999-12-31T23:59:59.999Z");
+
+  return (
+    effectiveStart.getTime() <= rangeEnd.getTime() &&
+    effectiveEnd.getTime() >= rangeStart.getTime()
+  );
+}
+
+function normalizeStartOfDay(date: Date) {
+  const next = new Date(date);
+  next.setHours(0, 0, 0, 0);
+  return next;
+}
+
+function normalizeEndOfDay(date: Date) {
+  const next = new Date(date);
+  next.setHours(23, 59, 59, 999);
+  return next;
+}
+
+function subtractDays(date: Date, days: number) {
+  const next = new Date(date);
+  next.setDate(next.getDate() - days);
+  return next;
+}

--- a/src/components/feature/vendor/dashboard/vendor-dashboard-insights-highlights.tsx
+++ b/src/components/feature/vendor/dashboard/vendor-dashboard-insights-highlights.tsx
@@ -1,0 +1,121 @@
+/** @format */
+
+"use client";
+
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { PackageSearch, Target, ExternalLink } from "lucide-react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+
+import { useVendorDashboardData } from "./vendor-dashboard-data-provider";
+
+export function VendorDashboardInsightsHighlights() {
+  const {
+    mostActiveClient,
+    productWithMostTickets,
+    isLoading,
+    isValidating,
+  } = useVendorDashboardData();
+
+  const loading = isLoading || isValidating;
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      <InsightCard
+        title="Tenant Paling Aktif"
+        icon={<Target className="h-5 w-5 text-muted-foreground" />}
+        loading={loading}
+        emptyMessage="Belum ada tenant dengan aktivitas tiket menonjol."
+        action={
+          mostActiveClient
+            ? {
+                href: `/vendor/clients?tenantId=${mostActiveClient.client_id}`,
+                label: "Buka tenant",
+              }
+            : undefined
+        }
+      >
+        {mostActiveClient ? (
+          <div className="space-y-1">
+            <p className="text-base font-semibold">{mostActiveClient.name}</p>
+            <p className="text-sm text-muted-foreground">
+              {mostActiveClient.ticket_count} tiket dalam 30 hari terakhir
+            </p>
+          </div>
+        ) : null}
+      </InsightCard>
+
+      <InsightCard
+        title="Produk dengan Eskalasi Tertinggi"
+        icon={<PackageSearch className="h-5 w-5 text-muted-foreground" />}
+        loading={loading}
+        emptyMessage="Tidak ada produk dengan tiket tinggi saat ini."
+        action={
+          productWithMostTickets
+            ? {
+                href: `/vendor/tickets?productId=${productWithMostTickets.product_id}`,
+                label: "Lihat tiket",
+              }
+            : undefined
+        }
+      >
+        {productWithMostTickets ? (
+          <div className="space-y-1">
+            <p className="text-base font-semibold">{productWithMostTickets.name}</p>
+            <p className="text-sm text-muted-foreground">
+              {productWithMostTickets.ticket_count} tiket aktif
+            </p>
+          </div>
+        ) : null}
+      </InsightCard>
+    </div>
+  );
+}
+
+function InsightCard({
+  title,
+  icon,
+  loading,
+  emptyMessage,
+  action,
+  children,
+}: {
+  title: string;
+  icon: ReactNode;
+  loading?: boolean;
+  emptyMessage: string;
+  action?: { href: string; label: string };
+  children?: ReactNode;
+}) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <div className="space-y-1">
+          <CardTitle className="text-sm font-medium">{title}</CardTitle>
+        </div>
+        {icon}
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {loading ? (
+          <Skeleton className="h-16 w-full" />
+        ) : children ? (
+          children
+        ) : (
+          <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+        )}
+
+        {action ? (
+          <Button variant="outline" size="sm" asChild className="gap-1">
+            <Link href={action.href}>
+              {action.label}
+              <ExternalLink className="h-3.5 w-3.5" />
+            </Link>
+          </Button>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/feature/vendor/dashboard/vendor-dashboard-login-leaderboard.tsx
+++ b/src/components/feature/vendor/dashboard/vendor-dashboard-login-leaderboard.tsx
@@ -1,0 +1,344 @@
+/** @format */
+
+"use client";
+
+import { useMemo } from "react";
+import Link from "next/link";
+import useSWR from "swr";
+import {
+  ArrowDownRight,
+  ArrowUpRight,
+  Minus,
+  Activity,
+  ExternalLink,
+} from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ensureSuccess } from "@/lib/api";
+import { listUsers } from "@/services/api";
+import type { Client, User } from "@/types/api";
+
+import { useVendorDashboardFilters } from "./vendor-dashboard-filter-context";
+import { useVendorDashboardTenantUniverse } from "./vendor-dashboard-tenant-data";
+import {
+  buildRangeCacheKey,
+  isDateWithinRange,
+  resolveDashboardDateRanges,
+} from "./vendor-dashboard-date-utils";
+
+type TenantLoginLeaderboardEntry = {
+  tenantId: number;
+  tenantName: string;
+  tenantType?: Client["type"];
+  currentCount: number;
+  previousCount: number;
+  trend: number;
+  trendDirection: "up" | "down" | "flat";
+  lastLoginAt: Date | null;
+};
+
+type TenantLoginLeaderboardResult = {
+  entries: TenantLoginLeaderboardEntry[];
+  totalTenants: number;
+  totalLogins: number;
+};
+
+const MAX_ROWS = 5;
+
+export function VendorDashboardLoginLeaderboard() {
+  const { filters } = useVendorDashboardFilters();
+  const { filteredClients } = useVendorDashboardTenantUniverse();
+
+  const tenantLookup = useMemo(() => {
+    const map = new Map<number, Pick<Client, "id" | "name" | "type">>();
+    for (const client of filteredClients) {
+      map.set(client.id, {
+        id: client.id,
+        name: client.name ?? `Tenant #${client.id}`,
+        type: client.type,
+      });
+    }
+    return map;
+  }, [filteredClients]);
+
+  const tenantIds = useMemo(() => {
+    return [...tenantLookup.keys()].sort((a, b) => a - b);
+  }, [tenantLookup]);
+
+  const resolvedRanges = useMemo(
+    () => resolveDashboardDateRanges(filters.dateRange ?? null),
+    [filters.dateRange],
+  );
+
+  const cacheKey = useMemo(() => {
+    return tenantIds.length
+      ? [
+          "vendor-dashboard",
+          "tenant-login-leaderboard",
+          tenantIds.join(","),
+          buildRangeCacheKey(resolvedRanges),
+        ]
+      : null;
+  }, [tenantIds, resolvedRanges]);
+
+  const { data, error, isLoading } = useSWR<TenantLoginLeaderboardResult>(
+    cacheKey,
+    async () =>
+      fetchTenantLoginLeaderboard({
+        tenantIds,
+        tenantLookup,
+        ranges: resolvedRanges,
+      }),
+    {
+      revalidateOnFocus: false,
+      keepPreviousData: true,
+    },
+  );
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between space-y-0">
+        <div>
+          <CardTitle className="text-base font-semibold">
+            Leaderboard Login Tenant
+          </CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Aktivitas login pengguna unik berdasarkan tenant pada periode terpilih.
+          </p>
+        </div>
+        <Badge variant="outline" className="gap-1">
+          <Activity className="h-3.5 w-3.5" />
+          {tenantIds.length ? `${tenantIds.length} tenant` : "Tidak ada data"}
+        </Badge>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isLoading ? (
+          <LeaderboardSkeleton />
+        ) : error ? (
+          <p className="text-sm text-destructive">
+            Gagal memuat data login tenant. Coba perbarui filter atau muat ulang halaman.
+          </p>
+        ) : !data || !data.entries.length ? (
+          <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+            Belum ada aktivitas login pada rentang tanggal ini.
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <ol className="space-y-3">
+              {data.entries.slice(0, MAX_ROWS).map((entry, index) => (
+                <li
+                  key={entry.tenantId}
+                  className="flex items-start justify-between gap-4 rounded-lg border p-4"
+                >
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2 text-sm font-semibold">
+                      <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-muted text-xs font-bold">
+                        {index + 1}
+                      </span>
+                      <span className="truncate text-base font-semibold">
+                        {entry.tenantName}
+                      </span>
+                    </div>
+                    <p className="text-sm text-muted-foreground capitalize">
+                      {entry.tenantType ?? "-"}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {entry.lastLoginAt
+                        ? `Login terakhir ${formatDistanceToNow(entry.lastLoginAt, {
+                            addSuffix: true,
+                          })}`
+                        : "Belum ada catatan login"}
+                    </p>
+                  </div>
+
+                  <div className="flex shrink-0 flex-col items-end gap-2 text-right">
+                    <div className="flex items-center gap-2">
+                      <span className="text-2xl font-semibold">
+                        {entry.currentCount}
+                      </span>
+                      <TrendBadge entry={entry} />
+                    </div>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="h-8 gap-1"
+                      asChild
+                    >
+                      <Link href={`/vendor/clients?tenantId=${entry.tenantId}`}>
+                        Lihat aktivitas
+                        <ExternalLink className="h-3.5 w-3.5" />
+                      </Link>
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ol>
+            {data.entries.length > MAX_ROWS ? (
+              <p className="text-xs text-muted-foreground">
+                Menampilkan {MAX_ROWS} teratas dari {data.entries.length} tenant.
+              </p>
+            ) : null}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function TrendBadge({ entry }: { entry: TenantLoginLeaderboardEntry }) {
+  const { trendDirection, trend } = entry;
+  if (trendDirection === "flat") {
+    return (
+      <Badge variant="secondary" className="gap-1">
+        <Minus className="h-3.5 w-3.5" /> 0%
+      </Badge>
+    );
+  }
+
+  const Icon = trendDirection === "up" ? ArrowUpRight : ArrowDownRight;
+  const variant: "default" | "destructive" =
+    trendDirection === "up" ? "default" : "destructive";
+
+  return (
+    <Badge variant={variant} className="gap-1">
+      <Icon className="h-3.5 w-3.5" />
+      {formatTrendValue(trend)}
+    </Badge>
+  );
+}
+
+function LeaderboardSkeleton() {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: MAX_ROWS }).map((_, index) => (
+        <div
+          key={index}
+          className="flex items-center justify-between gap-4 rounded-lg border p-4"
+        >
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-36" />
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-3 w-20" />
+          </div>
+          <div className="flex flex-col items-end gap-2">
+            <Skeleton className="h-6 w-12" />
+            <Skeleton className="h-8 w-28" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+async function fetchTenantLoginLeaderboard({
+  tenantIds,
+  tenantLookup,
+  ranges,
+}: {
+  tenantIds: number[];
+  tenantLookup: Map<number, Pick<Client, "id" | "name" | "type">>;
+  ranges: ReturnType<typeof resolveDashboardDateRanges>;
+}): Promise<TenantLoginLeaderboardResult> {
+  if (!tenantIds.length) {
+    return { entries: [], totalTenants: 0, totalLogins: 0 };
+  }
+
+  const entries: TenantLoginLeaderboardEntry[] = [];
+  const concurrency = 5;
+
+  for (let i = 0; i < tenantIds.length; i += concurrency) {
+    const batch = tenantIds.slice(i, i + concurrency);
+    const results = await Promise.all(
+      batch.map(async (tenantId) => {
+        try {
+          const response = await listUsers({ tenant_id: tenantId, limit: 200 });
+          const users = ensureSuccess<User[]>(response);
+          return { tenantId, users };
+        } catch (_err) {
+          return { tenantId, users: [] as User[] };
+        }
+      }),
+    );
+
+    for (const result of results) {
+      const { tenantId, users } = result;
+      const meta = tenantLookup.get(tenantId);
+      if (!meta) continue;
+
+      let currentCount = 0;
+      let previousCount = 0;
+      let lastLoginAt: Date | null = null;
+
+      for (const user of users ?? []) {
+        if (!user.last_login) continue;
+        const lastLogin = new Date(user.last_login);
+        if (Number.isNaN(lastLogin.getTime())) continue;
+
+        if (isDateWithinRange(lastLogin, ranges.current.start, ranges.current.end)) {
+          currentCount += 1;
+        } else if (
+          isDateWithinRange(lastLogin, ranges.previous.start, ranges.previous.end)
+        ) {
+          previousCount += 1;
+        }
+
+        if (!lastLoginAt || lastLogin > lastLoginAt) {
+          lastLoginAt = lastLogin;
+        }
+      }
+
+      const trendDirection =
+        currentCount > previousCount
+          ? "up"
+          : currentCount < previousCount
+            ? "down"
+            : "flat";
+      const trend = computeTrend(currentCount, previousCount);
+
+      entries.push({
+        tenantId,
+        tenantName: meta.name,
+        tenantType: meta.type,
+        currentCount,
+        previousCount,
+        trend,
+        trendDirection,
+        lastLoginAt,
+      });
+    }
+  }
+
+  entries.sort((a, b) => {
+    if (b.currentCount !== a.currentCount) {
+      return b.currentCount - a.currentCount;
+    }
+    const aTime = a.lastLoginAt?.getTime() ?? 0;
+    const bTime = b.lastLoginAt?.getTime() ?? 0;
+    return bTime - aTime;
+  });
+
+  const totalLogins = entries.reduce((sum, entry) => sum + entry.currentCount, 0);
+
+  return {
+    entries,
+    totalTenants: tenantIds.length,
+    totalLogins,
+  };
+}
+
+function computeTrend(current: number, previous: number) {
+  if (previous === 0) {
+    return current > 0 ? 100 : 0;
+  }
+  return ((current - previous) / previous) * 100;
+}
+
+function formatTrendValue(value: number) {
+  const rounded = Math.round(value * 10) / 10;
+  const display = Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1);
+  return `${display}%`;
+}

--- a/src/components/feature/vendor/dashboard/vendor-dashboard-module-adoption.tsx
+++ b/src/components/feature/vendor/dashboard/vendor-dashboard-module-adoption.tsx
@@ -1,0 +1,389 @@
+/** @format */
+
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import useSWR from "swr";
+import { BarChart3, Users, PowerOff } from "lucide-react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ensureSuccess } from "@/lib/api";
+import { listTenantModules } from "@/services/api";
+import type { Client, TenantModule } from "@/types/api";
+
+import { useVendorDashboardFilters } from "./vendor-dashboard-filter-context";
+import { useVendorDashboardTenantUniverse } from "./vendor-dashboard-tenant-data";
+import {
+  buildRangeCacheKey,
+  intervalOverlapsRange,
+  resolveDashboardDateRanges,
+} from "./vendor-dashboard-date-utils";
+
+type ModuleAdoptionEntry = {
+  moduleId: string;
+  code: string;
+  name: string;
+  activeTenants: number;
+  inactiveTenants: number;
+  adoptionRate: number;
+  activeTenantIds: number[];
+  inactiveTenantIds: number[];
+};
+
+type ModuleAdoptionResult = {
+  entries: ModuleAdoptionEntry[];
+  totalTenants: number;
+};
+
+export function VendorDashboardModuleAdoption() {
+  const { filters } = useVendorDashboardFilters();
+  const { filteredClients } = useVendorDashboardTenantUniverse();
+  const [selectedModuleId, setSelectedModuleId] = useState<string | null>(null);
+
+  const tenantLookup = useMemo(() => {
+    const map = new Map<number, Pick<Client, "id" | "name" | "type">>();
+    for (const client of filteredClients) {
+      map.set(client.id, {
+        id: client.id,
+        name: client.name ?? `Tenant #${client.id}`,
+        type: client.type,
+      });
+    }
+    return map;
+  }, [filteredClients]);
+
+  const tenantIds = useMemo(
+    () => [...tenantLookup.keys()].sort((a, b) => a - b),
+    [tenantLookup],
+  );
+
+  const resolvedRanges = useMemo(
+    () => resolveDashboardDateRanges(filters.dateRange ?? null),
+    [filters.dateRange],
+  );
+
+  const cacheKey = useMemo(() => {
+    return tenantIds.length
+      ? [
+          "vendor-dashboard",
+          "module-adoption",
+          tenantIds.join(","),
+          buildRangeCacheKey(resolvedRanges),
+        ]
+      : null;
+  }, [tenantIds, resolvedRanges]);
+
+  const { data, error, isLoading } = useSWR<ModuleAdoptionResult>(
+    cacheKey,
+    async () =>
+      fetchModuleAdoption({
+        tenantIds,
+        tenantLookup,
+        ranges: resolvedRanges,
+      }),
+    {
+      revalidateOnFocus: false,
+      keepPreviousData: true,
+    },
+  );
+
+  const selectedModule = useMemo(() => {
+    if (!data?.entries.length || !selectedModuleId) return null;
+    return data.entries.find((entry) => entry.moduleId === selectedModuleId) ?? null;
+  }, [data?.entries, selectedModuleId]);
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex flex-row items-start justify-between space-y-0">
+          <div>
+            <CardTitle className="text-base font-semibold">
+              Adopsi Modul Aktif
+            </CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Persentase tenant yang mengaktifkan modul pada rentang tanggal terpilih.
+            </p>
+          </div>
+          <Badge variant="outline" className="gap-1">
+            <BarChart3 className="h-3.5 w-3.5" />
+            {tenantIds.length ? `${tenantIds.length} tenant` : "Tidak ada data"}
+          </Badge>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {isLoading ? (
+            <ModuleAdoptionSkeleton />
+          ) : error ? (
+            <p className="text-sm text-destructive">
+              Gagal memuat ringkasan modul. Silakan coba lagi nanti.
+            </p>
+          ) : !data?.entries.length ? (
+            <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+              Belum ada modul aktif yang cocok dengan filter saat ini.
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {data.entries.map((entry) => (
+                <ModuleAdoptionRow
+                  key={entry.moduleId}
+                  entry={entry}
+                  onViewTenants={() => setSelectedModuleId(entry.moduleId)}
+                />
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <ModuleTenantDialog
+        module={selectedModule}
+        tenantLookup={tenantLookup}
+        open={Boolean(selectedModule)}
+        onOpenChange={(open) => !open && setSelectedModuleId(null)}
+      />
+    </>
+  );
+}
+
+function ModuleAdoptionRow({
+  entry,
+  onViewTenants,
+}: {
+  entry: ModuleAdoptionEntry;
+  onViewTenants: () => void;
+}) {
+  const inactiveLabel = `${entry.inactiveTenants} tenant menonaktifkan modul`;
+
+  return (
+    <div className="space-y-3 rounded-lg border p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <p className="text-base font-semibold">{entry.name}</p>
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            {entry.code}
+          </p>
+        </div>
+        <div className="text-right">
+          <p className="text-2xl font-semibold">{entry.adoptionRate.toFixed(0)}%</p>
+          <p className="text-xs text-muted-foreground">
+            {entry.activeTenants} tenant aktif
+          </p>
+        </div>
+      </div>
+
+      <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+        <div
+          className="h-full rounded-full bg-primary transition-[width]"
+          style={{ width: `${Math.min(entry.adoptionRate, 100)}%` }}
+        />
+      </div>
+
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <div className="inline-flex items-center gap-1">
+          <PowerOff className="h-3.5 w-3.5" />
+          {inactiveLabel}
+        </div>
+        <Button size="sm" variant="outline" className="h-8" onClick={onViewTenants}>
+          Lihat tenant
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ModuleTenantDialog({
+  module,
+  tenantLookup,
+  open,
+  onOpenChange,
+}: {
+  module: ModuleAdoptionEntry | null;
+  tenantLookup: Map<number, Pick<Client, "id" | "name" | "type">>;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>{module?.name ?? "Detail modul"}</DialogTitle>
+          <DialogDescription>
+            Ringkasan tenant yang mengaktifkan maupun menonaktifkan modul.
+          </DialogDescription>
+        </DialogHeader>
+
+        {module ? (
+          <div className="space-y-6">
+            <section className="space-y-3">
+              <div className="flex items-center gap-2 text-sm font-semibold">
+                <Users className="h-4 w-4" /> Tenant aktif ({module.activeTenants})
+              </div>
+              <TenantList tenantIds={module.activeTenantIds} tenantLookup={tenantLookup} />
+            </section>
+
+            <section className="space-y-3">
+              <div className="flex items-center gap-2 text-sm font-semibold text-muted-foreground">
+                <PowerOff className="h-4 w-4" /> Dinonaktifkan ({module.inactiveTenants})
+              </div>
+              <TenantList tenantIds={module.inactiveTenantIds} tenantLookup={tenantLookup} />
+            </section>
+          </div>
+        ) : (
+          <Skeleton className="h-32 w-full" />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function TenantList({
+  tenantIds,
+  tenantLookup,
+}: {
+  tenantIds: number[];
+  tenantLookup: Map<number, Pick<Client, "id" | "name" | "type">>;
+}) {
+  if (!tenantIds.length) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Tidak ada tenant pada kategori ini.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="space-y-2">
+      {tenantIds.map((tenantId) => {
+        const meta = tenantLookup.get(tenantId);
+        if (!meta) return null;
+        return (
+          <li key={tenantId} className="flex items-center justify-between gap-3">
+            <div>
+              <p className="text-sm font-medium">{meta.name}</p>
+              <p className="text-xs text-muted-foreground capitalize">{meta.type ?? "-"}</p>
+            </div>
+            <Button variant="link" className="h-auto p-0 text-sm" asChild>
+              <Link href={`/vendor/clients?tenantId=${tenantId}`}>Buka profil</Link>
+            </Button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function ModuleAdoptionSkeleton() {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: 3 }).map((_, index) => (
+        <div key={index} className="space-y-3 rounded-lg border p-4">
+          <div className="flex items-center justify-between">
+            <Skeleton className="h-4 w-36" />
+            <Skeleton className="h-6 w-12" />
+          </div>
+          <Skeleton className="h-2 w-full" />
+          <Skeleton className="h-4 w-32" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+async function fetchModuleAdoption({
+  tenantIds,
+  tenantLookup,
+  ranges,
+}: {
+  tenantIds: number[];
+  tenantLookup: Map<number, Pick<Client, "id" | "name" | "type">>;
+  ranges: ReturnType<typeof resolveDashboardDateRanges>;
+}): Promise<ModuleAdoptionResult> {
+  if (!tenantIds.length) {
+    return { entries: [], totalTenants: 0 };
+  }
+
+  const moduleMap = new Map<string, ModuleAdoptionEntry>();
+  const concurrency = 5;
+
+  for (let i = 0; i < tenantIds.length; i += concurrency) {
+    const batch = tenantIds.slice(i, i + concurrency);
+    const results = await Promise.all(
+      batch.map(async (tenantId) => {
+        try {
+          const response = await listTenantModules(tenantId, { limit: 200 });
+          const modules = ensureSuccess<TenantModule[]>(response);
+          return { tenantId, modules };
+        } catch (_err) {
+          return { tenantId, modules: [] as TenantModule[] };
+        }
+      }),
+    );
+
+    for (const { tenantId, modules } of results) {
+      if (!tenantLookup.has(tenantId)) continue;
+
+      for (const tenantModule of modules ?? []) {
+        const id = String(tenantModule.module_id ?? tenantModule.id);
+        const existing = moduleMap.get(id);
+        const base: ModuleAdoptionEntry =
+          existing ?? {
+            moduleId: id,
+            code: tenantModule.code,
+            name: tenantModule.name,
+            activeTenants: 0,
+            inactiveTenants: 0,
+            adoptionRate: 0,
+            activeTenantIds: [],
+            inactiveTenantIds: [],
+          };
+
+        const overlapsCurrent = intervalOverlapsRange(
+          tenantModule.start_date ?? null,
+          tenantModule.end_date ?? null,
+          ranges.current.start,
+          ranges.current.end,
+        );
+
+        if (tenantModule.status === "aktif" && overlapsCurrent) {
+          base.activeTenants += 1;
+          base.activeTenantIds.push(tenantId);
+        }
+
+        const endedInRange = intervalOverlapsRange(
+          tenantModule.start_date ?? null,
+          tenantModule.end_date ?? tenantModule.start_date ?? null,
+          ranges.current.start,
+          ranges.current.end,
+        );
+
+        if (tenantModule.status === "nonaktif" && endedInRange) {
+          base.inactiveTenants += 1;
+          base.inactiveTenantIds.push(tenantId);
+        }
+
+        moduleMap.set(id, base);
+      }
+    }
+  }
+
+  const totalTenants = tenantIds.length;
+  const entries = Array.from(moduleMap.values())
+    .map((entry) => ({
+      ...entry,
+      adoptionRate:
+        totalTenants > 0 ? Math.min((entry.activeTenants / totalTenants) * 100, 100) : 0,
+    }))
+    .sort((a, b) => b.adoptionRate - a.adoptionRate || b.activeTenants - a.activeTenants);
+
+  return { entries, totalTenants };
+}

--- a/src/components/feature/vendor/dashboard/vendor-dashboard-tenant-data.ts
+++ b/src/components/feature/vendor/dashboard/vendor-dashboard-tenant-data.ts
@@ -1,0 +1,194 @@
+/** @format */
+
+"use client";
+
+import { useMemo } from "react";
+import useSWR, { type SWRResponse } from "swr";
+
+import { ensureSuccess } from "@/lib/api";
+import {
+  listClients,
+  listVendorSubscriptions,
+  getVendorSubscriptionsSummary,
+} from "@/services/api";
+import type { Client, Subscription, SubscriptionSummary } from "@/types/api";
+
+import { useVendorDashboardFilters } from "./vendor-dashboard-filter-context";
+
+export type VendorDashboardTenantUniverse = {
+  clientsState: SWRResponse<Client[], any>;
+  subscriptionsState: SWRResponse<Subscription[], any>;
+  subscriptionSummaryState: SWRResponse<SubscriptionSummary | null, any>;
+  filteredClients: Client[];
+  filteredClientIds: Set<number>;
+  filteredSubscriptions: Subscription[];
+  subscriptionStatusByTenant: Map<number, Subscription["status"]>;
+  tenantDataLoading: boolean;
+  tenantDataError: unknown;
+};
+
+export function useVendorDashboardTenantUniverse(): VendorDashboardTenantUniverse {
+  const { filters } = useVendorDashboardFilters();
+
+  const tenantTypeParam =
+    filters.tenantType !== "all" ? filters.tenantType : undefined;
+  const subscriptionStatusParam = mapSubscriptionStatusFilter(
+    filters.subscriptionStatus,
+  );
+
+  const clientParams = useMemo(
+    () => ({
+      limit: 200,
+      ...(tenantTypeParam ? { type: tenantTypeParam } : {}),
+    }),
+    [tenantTypeParam],
+  );
+
+  const clientsState = useSWR<Client[]>(
+    ["vendor-dashboard", "clients", clientParams],
+    async ([, , params]) => ensureSuccess(await listClients(params)),
+    {
+      keepPreviousData: true,
+      revalidateOnFocus: false,
+    },
+  );
+
+  const subscriptionSummaryState = useSWR<SubscriptionSummary | null>(
+    ["vendor-dashboard", "subscriptions", "summary"],
+    async () => ensureSuccess(await getVendorSubscriptionsSummary()),
+    {
+      revalidateOnFocus: false,
+    },
+  );
+
+  const subscriptionParams = useMemo(
+    () => ({
+      limit: 200,
+      ...(subscriptionStatusParam ? { status: subscriptionStatusParam } : {}),
+    }),
+    [subscriptionStatusParam],
+  );
+
+  const subscriptionsState = useSWR<Subscription[]>(
+    ["vendor-dashboard", "subscriptions", subscriptionParams],
+    async ([, , params]) => ensureSuccess(await listVendorSubscriptions(params)),
+    {
+      keepPreviousData: true,
+      revalidateOnFocus: false,
+    },
+  );
+
+  const subscriptionStatusByTenant = useMemo(() => {
+    const map = new Map<number, Subscription["status"]>();
+    for (const sub of subscriptionsState.data ?? []) {
+      if (typeof sub?.tenant_id === "number" && sub.status) {
+        map.set(sub.tenant_id, sub.status);
+      }
+    }
+    return map;
+  }, [subscriptionsState.data]);
+
+  const filteredClients = useMemo(() => {
+    return (clientsState.data ?? []).filter((client) =>
+      matchesTenantFilters(client, filters.subscriptionStatus, subscriptionStatusByTenant),
+    );
+  }, [clientsState.data, filters.subscriptionStatus, subscriptionStatusByTenant]);
+
+  const filteredClientIds = useMemo(
+    () => new Set(filteredClients.map((client) => client.id)),
+    [filteredClients],
+  );
+
+  const filteredSubscriptions = useMemo(() => {
+    return (subscriptionsState.data ?? []).filter((subscription) =>
+      filteredClientIds.has(subscription.tenant_id),
+    );
+  }, [filteredClientIds, subscriptionsState.data]);
+
+  const tenantDataLoading = Boolean(
+    clientsState.isLoading ||
+      clientsState.isValidating ||
+      subscriptionsState.isLoading ||
+      subscriptionsState.isValidating,
+  );
+
+  const tenantDataError = clientsState.error || subscriptionsState.error;
+
+  return {
+    clientsState,
+    subscriptionsState,
+    subscriptionSummaryState,
+    filteredClients,
+    filteredClientIds,
+    filteredSubscriptions,
+    subscriptionStatusByTenant,
+    tenantDataLoading,
+    tenantDataError,
+  };
+}
+
+export function mapSubscriptionStatusFilter(
+  filter: ReturnType<typeof useVendorDashboardFilters>["filters"]["subscriptionStatus"],
+) {
+  switch (filter) {
+    case "active":
+      return "active";
+    case "trial":
+      return "pending";
+    case "cancelled":
+      return "terminated";
+    case "expired":
+      return "overdue";
+    default:
+      return undefined;
+  }
+}
+
+export function translateSubscriptionFilter(
+  filter: ReturnType<typeof useVendorDashboardFilters>["filters"]["subscriptionStatus"],
+) {
+  switch (filter) {
+    case "active":
+      return "aktif";
+    case "trial":
+      return "trial";
+    case "cancelled":
+      return "dibatalkan";
+    case "expired":
+      return "kedaluwarsa";
+    default:
+      return "semua status";
+  }
+}
+
+export function matchesTenantFilters(
+  client: Client,
+  filter: ReturnType<typeof useVendorDashboardFilters>["filters"]["subscriptionStatus"],
+  subscriptionStatusByTenant: Map<number, Subscription["status"]>,
+) {
+  const subscriptionStatus = subscriptionStatusByTenant.get(client.id);
+
+  switch (filter) {
+    case "active":
+      return client.status === "active";
+    case "trial":
+      return (
+        client.status === "inactive" ||
+        client.status === "suspended" ||
+        subscriptionStatus === "pending"
+      );
+    case "cancelled":
+      return (
+        client.status === "inactive" ||
+        subscriptionStatus === "terminated" ||
+        subscriptionStatus === "paused"
+      );
+    case "expired":
+      return (
+        client.status === "suspended" ||
+        subscriptionStatus === "overdue"
+      );
+    default:
+      return true;
+  }
+}

--- a/src/services/api/users.ts
+++ b/src/services/api/users.ts
@@ -15,6 +15,7 @@ export function listUsers(
     term?: string;
     status?: string;
     role_id?: string | number;
+    tenant_id?: string | number;
     limit?: number;
     cursor?: string;
   },
@@ -26,6 +27,8 @@ export function listUsers(
   if (params?.term) search.set("term", params.term);
   if (params?.status) search.set("status", params.status);
   if (params?.role_id) search.set("role_id", String(params.role_id));
+  if (params?.tenant_id)
+    search.set("tenant_id", String(params.tenant_id));
   const query = search.toString() ? `?${search.toString()}` : "";
   return api.get<User[]>(
     `${API_PREFIX}${API_ENDPOINTS.users.list}${query}`,


### PR DESCRIPTION
## Summary
- add shared vendor dashboard tenant data utilities and expose new engagement widgets for login activity and module adoption
- surface most active client and product ticket highlights and integrate the new widgets into the vendor dashboard layout
- support tenant-specific deep linking by extending the user listing API and client management page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0ea95884c8322a42b639d7c0e2825