### PR TITLE
Add vendor dashboard drilldown pages

### DIFF
--- a/src/app/(main)/vendor/dashboard/layout.tsx
+++ b/src/app/(main)/vendor/dashboard/layout.tsx
@@ -1,0 +1,67 @@
+/** @format */
+
+"use client";
+
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { VendorDashboardFilterProvider } from "@/components/feature/vendor/dashboard/vendor-dashboard-filter-context";
+
+const detailNavigation = [
+  { href: "/vendor/dashboard/tenant-activity", label: "Aktivitas Tenant" },
+  { href: "/vendor/dashboard/revenue-trend", label: "Tren Pendapatan" },
+  { href: "/vendor/dashboard/support-health", label: "Kesehatan Dukungan" },
+] as const;
+
+export default function VendorDashboardSectionLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const pathname = usePathname();
+  const isDetail = detailNavigation.some((item) =>
+    pathname ? pathname.startsWith(item.href) : false,
+  );
+
+  return (
+    <VendorDashboardFilterProvider>
+      <div className="space-y-6">
+        {isDetail ? (
+          <div className="flex flex-col gap-3 rounded-lg border bg-muted/30 p-4 sm:flex-row sm:items-center sm:justify-between">
+            <Link
+              href="/vendor/dashboard"
+              className="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Kembali ke dashboard utama
+            </Link>
+            <nav className="flex flex-wrap gap-2">
+              {detailNavigation.map((item) => {
+                const active = pathname?.startsWith(item.href);
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    className={cn(
+                      "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+                      active
+                        ? "bg-primary text-primary-foreground shadow-sm"
+                        : "bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground",
+                    )}
+                  >
+                    {item.label}
+                  </Link>
+                );
+              })}
+            </nav>
+          </div>
+        ) : null}
+
+        {children}
+      </div>
+    </VendorDashboardFilterProvider>
+  );
+}

--- a/src/app/(main)/vendor/dashboard/page.tsx
+++ b/src/app/(main)/vendor/dashboard/page.tsx
@@ -3,7 +3,6 @@
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { VendorDashboardFilterProvider } from "@/components/feature/vendor/dashboard/vendor-dashboard-filter-context";
 import { VendorDashboardDataProvider, useVendorDashboardData } from "@/components/feature/vendor/dashboard/vendor-dashboard-data-provider";
 import { VendorDashboardGlobalFilters } from "@/components/feature/vendor/dashboard/vendor-dashboard-filters";
 import { VendorDashboardKpiGrid } from "@/components/feature/vendor/dashboard/vendor-dashboard-kpi-grid";
@@ -16,14 +15,13 @@ import { VendorDashboardInvoiceWatchlist } from "@/components/feature/vendor/das
 import { VendorDashboardLoginLeaderboard } from "@/components/feature/vendor/dashboard/vendor-dashboard-login-leaderboard";
 import { VendorDashboardModuleAdoption } from "@/components/feature/vendor/dashboard/vendor-dashboard-module-adoption";
 import { VendorDashboardInsightsHighlights } from "@/components/feature/vendor/dashboard/vendor-dashboard-insights-highlights";
+import Link from "next/link";
 
 export default function VendorDashboardPage() {
   return (
-    <VendorDashboardFilterProvider>
-      <VendorDashboardDataProvider>
-        <VendorDashboardPageShell />
-      </VendorDashboardDataProvider>
-    </VendorDashboardFilterProvider>
+    <VendorDashboardDataProvider>
+      <VendorDashboardPageShell />
+    </VendorDashboardDataProvider>
   );
 }
 
@@ -46,6 +44,29 @@ function VendorDashboardPageShell() {
           <p className="text-sm text-muted-foreground">
             Ringkasan aktivitas tenant vendor dan status dukungan pelanggan.
           </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 pt-1 text-sm text-muted-foreground">
+          <span className="font-medium text-foreground">Telusuri detail:</span>
+          <div className="flex flex-wrap items-center gap-2">
+            <Link
+              href="/vendor/dashboard/tenant-activity"
+              className="rounded-md border px-3 py-1 font-medium text-foreground transition-colors hover:bg-muted"
+            >
+              Aktivitas Tenant
+            </Link>
+            <Link
+              href="/vendor/dashboard/revenue-trend"
+              className="rounded-md border px-3 py-1 font-medium text-foreground transition-colors hover:bg-muted"
+            >
+              Tren Pendapatan
+            </Link>
+            <Link
+              href="/vendor/dashboard/support-health"
+              className="rounded-md border px-3 py-1 font-medium text-foreground transition-colors hover:bg-muted"
+            >
+              Kesehatan Dukungan
+            </Link>
+          </div>
         </div>
       </header>
 

--- a/src/app/(main)/vendor/dashboard/revenue-trend/page.tsx
+++ b/src/app/(main)/vendor/dashboard/revenue-trend/page.tsx
@@ -1,0 +1,527 @@
+/** @format */
+
+"use client";
+
+import { useMemo, useState } from "react";
+import useSWR from "swr";
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { format, parseISO } from "date-fns";
+import { id as localeId } from "date-fns/locale";
+import { FileDown, LineChart } from "lucide-react";
+import { toast } from "sonner";
+
+import { ensureSuccess } from "@/lib/api";
+import {
+  exportVendorReportRaw,
+  getBillingReport,
+  getVendorFinancialReport,
+} from "@/services/api";
+import type {
+  BillingReportResponse,
+  OverdueInvoiceResponse,
+  VendorFinancialReport,
+} from "@/types/api";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+
+import { VendorDashboardGlobalFilters } from "@/components/feature/vendor/dashboard/vendor-dashboard-filters";
+import { useVendorDashboardDateParams } from "@/components/feature/vendor/dashboard/vendor-dashboard-hooks";
+
+const currencyFormatter = new Intl.NumberFormat("id-ID", {
+  style: "currency",
+  currency: "IDR",
+  maximumFractionDigits: 0,
+});
+
+const groupByOptions = [
+  { value: "month", label: "Bulanan" },
+  { value: "quarter", label: "Kuartal" },
+  { value: "year", label: "Tahunan" },
+] as const;
+
+const formatOptions = [
+  { value: "xlsx", label: "Spreadsheet (.xlsx)" },
+  { value: "pdf", label: "PDF" },
+] as const;
+
+type GroupByValue = (typeof groupByOptions)[number]["value"];
+type ExportFormatValue = (typeof formatOptions)[number]["value"];
+
+const revenueChartConfig = {
+  mrr: {
+    label: "MRR",
+    color: "hsl(var(--chart-1))",
+  },
+  arr: {
+    label: "ARR",
+    color: "hsl(var(--chart-2))",
+  },
+} satisfies ChartConfig;
+
+const statusChartConfig = {
+  paid: {
+    label: "Terbayar",
+    color: "hsl(var(--chart-2))",
+  },
+  pending: {
+    label: "Menunggu",
+    color: "hsl(var(--chart-3))",
+  },
+  overdue: {
+    label: "Terlambat",
+    color: "hsl(var(--chart-4))",
+  },
+} satisfies ChartConfig;
+
+export default function VendorRevenueTrendPage() {
+  const { start, end } = useVendorDashboardDateParams();
+  const [groupBy, setGroupBy] = useState<GroupByValue>("month");
+  const [exportFormat, setExportFormat] = useState<ExportFormatValue>("xlsx");
+  const [exporting, setExporting] = useState(false);
+
+  const financialKey = useMemo(
+    () => JSON.stringify({ start, end, groupBy }),
+    [start, end, groupBy],
+  );
+
+  const billingKey = useMemo(
+    () => JSON.stringify({ start, end }),
+    [start, end],
+  );
+
+  const {
+    data: financialData,
+    error: financialError,
+    isLoading: financialLoading,
+    isValidating: financialValidating,
+    mutate: refreshFinancial,
+  } = useSWR<VendorFinancialReport>(
+    ["vendor-dashboard", "revenue-trend", "financial", financialKey],
+    async () =>
+      ensureSuccess(
+        await getVendorFinancialReport({
+          start_date: start,
+          end_date: end,
+          group_by: groupBy,
+        }),
+      ),
+    {
+      keepPreviousData: true,
+      revalidateOnFocus: false,
+    },
+  );
+
+  const {
+    data: billingData,
+    error: billingError,
+    isLoading: billingLoading,
+    isValidating: billingValidating,
+    mutate: refreshBilling,
+  } = useSWR<BillingReportResponse>(
+    ["vendor-dashboard", "revenue-trend", "billing", billingKey],
+    async () => ensureSuccess(await getBillingReport({ start, end })),
+    {
+      keepPreviousData: true,
+      revalidateOnFocus: false,
+    },
+  );
+
+  const financialSeries = financialData?.series ?? [];
+  const revenueTotals = financialData?.totals ?? { mrr: 0, arr: 0 };
+  const billingStatus = billingData?.status_detail ?? {
+    paid: 0,
+    pending: 0,
+    overdue: 0,
+  };
+  const billingRevenue = billingData?.revenue ?? {
+    subscription: 0,
+    outstanding: 0,
+  };
+  const overdueInvoices = billingData?.overdue_invoices ?? [];
+  const totalInvoices = billingData?.total_invoices ?? 0;
+
+  const statusData = buildStatusChartData(billingStatus);
+  const statusTotal = statusData.reduce((sum, item) => sum + item.value, 0);
+
+  const loadingRevenueChart = financialLoading && !financialData;
+  const loadingBillingCards = billingLoading && !billingData;
+
+  async function handleExport() {
+    if (exporting) return;
+    setExporting(true);
+    try {
+      const blob = await exportVendorReportRaw({
+        report_type: "financial",
+        format: exportFormat,
+        params: {
+          start_date: start,
+          end_date: end,
+          group_by: groupBy,
+        },
+      });
+      const url = window.URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      const rangeLabel = [start, end].filter(Boolean).join("-" ) || "all";
+      anchor.download = `vendor-financial-report-${rangeLabel}.${exportFormat}`;
+      anchor.click();
+      window.URL.revokeObjectURL(url);
+      toast.success("Laporan finansial vendor berhasil diekspor");
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Gagal mengekspor laporan finansial";
+      toast.error(message);
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  const hasError = Boolean(financialError || billingError);
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-3">
+        <nav aria-label="Breadcrumb">
+          <ol className="flex items-center gap-2 text-sm text-muted-foreground">
+            <li>Vendor</li>
+            <li>/</li>
+            <li>Dashboard</li>
+            <li>/</li>
+            <li className="font-medium text-foreground">Tren Pendapatan</li>
+          </ol>
+        </nav>
+        <div className="space-y-1">
+          <h1 className="text-3xl font-semibold tracking-tight">
+            Tren Pendapatan & Billing
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Visualisasi mendalam laporan finansial vendor, status tagihan, dan proyeksi arus kas.
+          </p>
+        </div>
+      </header>
+
+      <VendorDashboardGlobalFilters />
+
+      <Card>
+        <CardHeader className="flex flex-col gap-4 pb-3 md:flex-row md:items-center md:justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <LineChart className="h-4 w-4" /> Rentang Analisis
+            </CardTitle>
+            <CardDescription>
+              Sesuaikan agregasi periode dan format ekspor untuk laporan finansial.
+            </CardDescription>
+          </div>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <Select value={groupBy} onValueChange={(value) => setGroupBy(value as GroupByValue)}>
+              <SelectTrigger className="w-[180px]">
+                <SelectValue placeholder="Kelompokkan" />
+              </SelectTrigger>
+              <SelectContent>
+                {groupByOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select
+              value={exportFormat}
+              onValueChange={(value) => setExportFormat(value as ExportFormatValue)}
+            >
+              <SelectTrigger className="w-[210px]">
+                <SelectValue placeholder="Format ekspor" />
+              </SelectTrigger>
+              <SelectContent>
+                {formatOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button
+              type="button"
+              variant="outline"
+              className="gap-2"
+              disabled={exporting}
+              onClick={handleExport}
+            >
+              <FileDown className="h-4 w-4" />
+              {exporting ? "Memproses…" : "Ekspor laporan"}
+            </Button>
+          </div>
+        </CardHeader>
+      </Card>
+
+      {hasError ? (
+        <Alert variant="destructive">
+          <AlertTitle>Data laporan tidak dapat dimuat</AlertTitle>
+          <AlertDescription className="flex flex-col gap-3">
+            <span>
+              {financialError instanceof Error
+                ? financialError.message
+                : billingError instanceof Error
+                  ? billingError.message
+                  : "Terjadi kesalahan saat mengambil data finansial."}
+            </span>
+            <div className="flex flex-wrap gap-2">
+              <Button size="sm" variant="outline" onClick={() => refreshFinancial()}>
+                Segarkan data finansial
+              </Button>
+              <Button size="sm" variant="outline" onClick={() => refreshBilling()}>
+                Segarkan data billing
+              </Button>
+            </div>
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      <div className="grid gap-6 xl:grid-cols-[2fr_1fr]">
+        <Card className="h-full">
+          <CardHeader className="flex flex-col gap-2 pb-2 sm:flex-row sm:items-start sm:justify-between">
+            <div className="space-y-1">
+              <CardTitle className="text-lg">Pendapatan Berulang (MRR & ARR)</CardTitle>
+              <CardDescription>
+                Lacak pertumbuhan pendapatan berdasarkan periode {groupByLabel(groupBy)}.
+              </CardDescription>
+            </div>
+            {financialValidating ? (
+              <span className="text-xs text-muted-foreground">Memperbarui data…</span>
+            ) : null}
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {loadingRevenueChart ? (
+              <Skeleton className="h-[280px] w-full" />
+            ) : financialSeries.length ? (
+              <>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <SummaryTile label="Total MRR" value={currencyFormatter.format(revenueTotals.mrr ?? 0)} />
+                  <SummaryTile label="Total ARR" value={currencyFormatter.format(revenueTotals.arr ?? 0)} />
+                </div>
+                <ChartContainer config={revenueChartConfig} className="h-[300px] w-full">
+                  <AreaChart data={financialSeries} margin={{ left: 12, right: 12, top: 16 }}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis dataKey="period" tickLine={false} axisLine={false} />
+                    <YAxis tickFormatter={(value) => currencyFormatter.format(value).replace(/,00$/, "")} width={90} />
+                    <ChartTooltip
+                      content={
+                        <ChartTooltipContent
+                          formatter={(value, name) => [
+                            currencyFormatter.format(Number(value)),
+                            name,
+                          ]}
+                        />
+                      }
+                    />
+                    <Area
+                      type="monotone"
+                      dataKey="mrr"
+                      stroke="var(--color-mrr)"
+                      fill="var(--color-mrr)"
+                      fillOpacity={0.18}
+                    />
+                    <Area
+                      type="monotone"
+                      dataKey="arr"
+                      stroke="var(--color-arr)"
+                      fill="var(--color-arr)"
+                      fillOpacity={0.18}
+                    />
+                  </AreaChart>
+                </ChartContainer>
+              </>
+            ) : (
+              <div className="flex h-[280px] items-center justify-center rounded-lg border text-sm text-muted-foreground">
+                Tidak ada data pendapatan berulang untuk filter saat ini.
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="h-full">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-lg">Kinerja Billing</CardTitle>
+            <CardDescription>
+              Ringkasan status tagihan dan komposisi pendapatan berdasarkan laporan billing API.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {billingValidating ? (
+              <span className="text-xs text-muted-foreground">Memperbarui data billing…</span>
+            ) : null}
+            {loadingBillingCards ? (
+              <Skeleton className="h-[220px] w-full" />
+            ) : (
+              <>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <SummaryTile label="Total invoice" value={totalInvoices.toLocaleString("id-ID")} />
+                  <SummaryTile
+                    label="Pendapatan langganan"
+                    value={currencyFormatter.format(billingRevenue.subscription ?? 0)}
+                  />
+                  <SummaryTile
+                    label="Tagihan outstanding"
+                    value={currencyFormatter.format(billingRevenue.outstanding ?? 0)}
+                  />
+                  <SummaryTile
+                    label="Nilai overdue"
+                    value={currencyFormatter.format(calculateOverdueValue(overdueInvoices))}
+                  />
+                </div>
+                <ChartContainer config={statusChartConfig} className="h-[220px] w-full">
+                  <BarChart data={statusData} margin={{ top: 16, left: 12, right: 12 }}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis dataKey="label" tickLine={false} axisLine={false} />
+                    <YAxis allowDecimals={false} />
+                    <ChartTooltip
+                      content={
+                        <ChartTooltipContent
+                          formatter={(value, name) => [
+                            `${Number(value).toLocaleString("id-ID")} invoice`,
+                            name,
+                          ]}
+                        />
+                      }
+                    />
+                    <Bar dataKey="value" radius={6} />
+                  </BarChart>
+                </ChartContainer>
+                <div className="grid gap-2 text-xs text-muted-foreground">
+                  {statusData.map((item) => (
+                    <div key={item.key} className="flex items-center justify-between">
+                      <span className="flex items-center gap-2">
+                        <span className="inline-block h-3 w-3 rounded-sm" style={{ background: `var(--color-${item.key})` }} />
+                        {item.label}
+                      </span>
+                      <span className="font-medium text-foreground">
+                        {item.value.toLocaleString("id-ID")} invoice
+                        {statusTotal
+                          ? ` (${Math.round((item.value / statusTotal) * 100)}%)`
+                          : ""}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-lg">Invoice Overdue Prioritas</CardTitle>
+          <CardDescription>
+            Data langsung dari endpoint <code>GET /api/reports/billing</code> untuk memantau risiko kas.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {overdueInvoices.length ? (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Nomor Invoice</TableHead>
+                  <TableHead>Tenant</TableHead>
+                  <TableHead className="text-right">Nilai</TableHead>
+                  <TableHead>Jatuh Tempo</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {overdueInvoices.map((invoice) => (
+                  <TableRow key={invoice.id}>
+                    <TableCell className="font-medium">{invoice.number}</TableCell>
+                    <TableCell>#{invoice.tenant_id}</TableCell>
+                    <TableCell className="text-right">
+                      {currencyFormatter.format(invoice.total ?? 0)}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="destructive">{formatInvoiceDueDate(invoice)}</Badge>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          ) : (
+            <div className="rounded-lg border bg-muted/30 p-6 text-sm text-muted-foreground">
+              Seluruh invoice dalam kondisi sehat. Tidak ada keterlambatan teridentifikasi.
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function buildStatusChartData(status: BillingReportResponse["status_detail"]) {
+  return [
+    { key: "paid", label: "Terbayar", value: status?.paid ?? 0 },
+    { key: "pending", label: "Menunggu", value: status?.pending ?? 0 },
+    { key: "overdue", label: "Terlambat", value: status?.overdue ?? 0 },
+  ];
+}
+
+function groupByLabel(value: string) {
+  const option = groupByOptions.find((item) => item.value === value);
+  return option?.label.toLowerCase() ?? "periode";
+}
+
+function SummaryTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border p-4">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-lg font-semibold">{value}</p>
+    </div>
+  );
+}
+
+function calculateOverdueValue(invoices: OverdueInvoiceResponse[]) {
+  return invoices.reduce((sum, invoice) => sum + (invoice.total ?? 0), 0);
+}
+
+function formatInvoiceDueDate(invoice: OverdueInvoiceResponse) {
+  try {
+    const parsed = parseISO(invoice.due_date);
+    return format(parsed, "d MMM yyyy", { locale: localeId });
+  } catch (_error) {
+    return invoice.due_date;
+  }
+}

--- a/src/app/(main)/vendor/dashboard/support-health/page.tsx
+++ b/src/app/(main)/vendor/dashboard/support-health/page.tsx
@@ -1,0 +1,649 @@
+/** @format */
+
+"use client";
+
+import { useMemo, type ReactNode } from "react";
+import useSWR from "swr";
+import { format, formatDistanceToNow, isWithinInterval, parseISO } from "date-fns";
+import { id as localeId } from "date-fns/locale";
+import { Activity, Clock, LifeBuoy, MessageCircle } from "lucide-react";
+
+import { ensureSuccess } from "@/lib/api";
+import { listTicketReplies, listTicketSLA, listTickets } from "@/services/api";
+import type { Ticket, TicketCategorySLA, TicketReply } from "@/types/api";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+import { VendorDashboardGlobalFilters } from "@/components/feature/vendor/dashboard/vendor-dashboard-filters";
+import { useVendorDashboardFilters } from "@/components/feature/vendor/dashboard/vendor-dashboard-filter-context";
+import {
+  useVendorDashboardTenantUniverse,
+} from "@/components/feature/vendor/dashboard/vendor-dashboard-tenant-data";
+import {
+  resolveDashboardDateRanges,
+  type VendorDashboardResolvedRanges,
+} from "@/components/feature/vendor/dashboard/vendor-dashboard-date-utils";
+
+export default function VendorSupportHealthPage() {
+  const { filters } = useVendorDashboardFilters();
+  const ranges = useMemo(
+    () => resolveDashboardDateRanges(filters.dateRange ?? null),
+    [filters.dateRange],
+  );
+  const { filteredClientIds } = useVendorDashboardTenantUniverse();
+
+  const tenantFilterKey = useMemo(() => Array.from(filteredClientIds).join("-"), [filteredClientIds]);
+
+  const {
+    data: tickets,
+    error: ticketsError,
+    isLoading: ticketsLoading,
+    isValidating: ticketsValidating,
+    mutate: refreshTickets,
+  } = useSWR<Ticket[]>(
+    [
+      "vendor-dashboard",
+      "support-health",
+      "tickets",
+      tenantFilterKey,
+      ranges.current.start.toISOString(),
+      ranges.current.end.toISOString(),
+    ],
+    async () => ensureSuccess(await listTickets({ limit: 200 })),
+    {
+      keepPreviousData: true,
+      revalidateOnFocus: false,
+    },
+  );
+
+  const {
+    data: sla,
+    error: slaError,
+    isLoading: slaLoading,
+    mutate: refreshSla,
+  } = useSWR<TicketCategorySLA[]>(
+    ["vendor-dashboard", "support-health", "sla"],
+    async () => ensureSuccess(await listTicketSLA()),
+    {
+      revalidateOnFocus: false,
+    },
+  );
+
+  const filteredTickets = useMemo(
+    () => filterTicketsByScope(tickets ?? [], filteredClientIds, ranges),
+    [filteredClientIds, ranges, tickets],
+  );
+
+  const metrics = useMemo(() => computeSupportMetrics(filteredTickets), [filteredTickets]);
+  const backlog = useMemo(() => buildBacklogSummaries(filteredTickets), [filteredTickets]);
+  const agentMetrics = useMemo(() => computeAgentMetrics(filteredTickets), [filteredTickets]);
+  const topTicketsForReplies = useMemo(
+    () =>
+      filteredTickets
+        .filter((ticket) => ticket.status !== "closed")
+        .sort((a, b) =>
+          new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+        )
+        .slice(0, 3),
+    [filteredTickets],
+  );
+
+  const loadingState = ticketsLoading && !tickets;
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-3">
+        <nav aria-label="Breadcrumb">
+          <ol className="flex items-center gap-2 text-sm text-muted-foreground">
+            <li>Vendor</li>
+            <li>/</li>
+            <li>Dashboard</li>
+            <li>/</li>
+            <li className="font-medium text-foreground">Kesehatan Dukungan</li>
+          </ol>
+        </nav>
+        <div className="space-y-1">
+          <h1 className="text-3xl font-semibold tracking-tight">
+            Kesehatan Operasional Dukungan
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Pantau SLA, backlog, serta performa agen vendor berdasarkan data tiket terbaru.
+          </p>
+        </div>
+      </header>
+
+      <VendorDashboardGlobalFilters />
+
+      {ticketsError ? (
+        <Alert variant="destructive">
+          <AlertTitle>Data tiket tidak dapat dimuat</AlertTitle>
+          <AlertDescription className="flex flex-col gap-3">
+            <span>
+              {ticketsError instanceof Error
+                ? ticketsError.message
+                : "Terjadi kesalahan saat mengambil daftar tiket."}
+            </span>
+            <Button size="sm" variant="outline" onClick={() => refreshTickets()}>
+              Coba lagi
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {slaError ? (
+        <Alert variant="destructive">
+          <AlertTitle>Konfigurasi SLA tidak dapat dimuat</AlertTitle>
+          <AlertDescription className="flex flex-col gap-3">
+            <span>
+              {slaError instanceof Error
+                ? slaError.message
+                : "Terjadi kesalahan saat mengambil konfigurasi SLA tiket."}
+            </span>
+            <Button size="sm" variant="outline" onClick={() => refreshSla()}>
+              Muat ulang SLA
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-lg">Ringkasan SLA & Beban Kerja</CardTitle>
+          <CardDescription>
+            Perhitungan berdasarkan {filteredTickets.length} tiket dalam rentang tanggal terpilih.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {loadingState ? (
+            <Skeleton className="h-28 w-full" />
+          ) : (
+            <div className="grid gap-4 sm:grid-cols-3">
+              <MetricTile
+                icon={<LifeBuoy className="h-4 w-4 text-primary" />}
+                label="Tiket aktif"
+                value={`${metrics.openTickets} tiket`}
+                helper={`Total ${metrics.totalTickets} tiket terpantau`}
+              />
+              <MetricTile
+                icon={<Clock className="h-4 w-4 text-primary" />}
+                label="Kepatuhan SLA respon"
+                value={formatPercentage(metrics.responseCompliance)}
+                helper={`Rata-rata respon awal ${formatMinutes(metrics.avgFirstResponseMinutes)}`}
+              />
+              <MetricTile
+                icon={<Activity className="h-4 w-4 text-primary" />}
+                label="Kepatuhan SLA resolusi"
+                value={formatPercentage(metrics.resolutionCompliance)}
+                helper={`Rata-rata resolusi ${formatMinutes(metrics.avgResolutionMinutes)}`}
+              />
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-6 lg:grid-cols-[1.1fr_1fr]">
+        <Card className="h-full">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-lg">Distribusi Backlog</CardTitle>
+            <CardDescription>
+              Status dan prioritas tiket yang masih membutuhkan tindakan.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {ticketsValidating ? (
+              <span className="text-xs text-muted-foreground">Memperbarui data tiket…</span>
+            ) : null}
+            {loadingState ? (
+              <Skeleton className="h-[180px] w-full" />
+            ) : (
+              <div className="grid gap-4 md:grid-cols-2">
+                <BacklogList title="Status" items={backlog.statuses} />
+                <BacklogList title="Prioritas" items={backlog.priorities} />
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="h-full">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-lg">Konfigurasi SLA per Kategori</CardTitle>
+            <CardDescription>
+              Data dari endpoint <code>GET /api/tickets/sla</code> untuk referensi operasional.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {slaLoading && !sla ? (
+              <Skeleton className="h-[180px] w-full" />
+            ) : sla && sla.length ? (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Kategori</TableHead>
+                    <TableHead className="text-right">Respon awal</TableHead>
+                    <TableHead className="text-right">Resolusi</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {sla.map((item) => (
+                    <TableRow key={item.category}>
+                      <TableCell className="capitalize">{item.category}</TableCell>
+                      <TableCell className="text-right">
+                        {formatMinutes(item.sla_response_minutes)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {formatMinutes(item.sla_resolution_minutes)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            ) : (
+              <div className="rounded-lg border bg-muted/30 p-4 text-sm text-muted-foreground">
+                Belum ada konfigurasi SLA yang terdaftar untuk kategori tiket.
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[1.2fr_1fr]">
+        <Card className="h-full">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-lg">Performa Agen Dukungan</CardTitle>
+            <CardDescription>
+              Rata-rata respon dan resolusi berdasarkan tiket yang ditangani.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {agentMetrics.length ? (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Agen</TableHead>
+                    <TableHead className="text-right">Tiket aktif</TableHead>
+                    <TableHead className="text-right">Respon rata-rata</TableHead>
+                    <TableHead className="text-right">Resolusi rata-rata</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {agentMetrics.map((agent) => (
+                    <TableRow key={agent.agentId}>
+                      <TableCell>
+                        <div className="flex flex-col">
+                          <span className="font-medium">Agen #{agent.agentId}</span>
+                          <span className="text-xs text-muted-foreground">
+                            {agent.totalTickets} tiket ditangani
+                          </span>
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-right">{agent.openTickets}</TableCell>
+                      <TableCell className="text-right">
+                        {formatMinutes(agent.avgFirstResponseMinutes)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {formatMinutes(agent.avgResolutionMinutes)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            ) : (
+              <div className="rounded-lg border bg-muted/30 p-4 text-sm text-muted-foreground">
+                Belum ada data kinerja agen untuk filter ini.
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="h-full">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-lg">Balasan Vendor Terbaru</CardTitle>
+            <CardDescription>
+              Sampel percakapan dari endpoint <code>GET /api/tickets/:id/vendor-replies</code>.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {topTicketsForReplies.length ? (
+              topTicketsForReplies.map((ticket) => (
+                <TicketRepliesPreview key={ticket.id} ticket={ticket} />
+              ))
+            ) : (
+              <div className="rounded-lg border bg-muted/30 p-4 text-sm text-muted-foreground">
+                Tidak ada tiket aktif yang membutuhkan balasan vendor saat ini.
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+type MetricTileProps = {
+  icon: ReactNode;
+  label: string;
+  value: string;
+  helper?: string;
+};
+
+function MetricTile({ icon, label, value, helper }: MetricTileProps) {
+  return (
+    <div className="rounded-lg border p-4">
+      <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+        {icon}
+        {label}
+      </div>
+      <p className="mt-2 text-lg font-semibold text-foreground">{value}</p>
+      {helper ? <p className="text-xs text-muted-foreground">{helper}</p> : null}
+    </div>
+  );
+}
+
+type BacklogItem = { label: string; value: number; helper?: string };
+
+function BacklogList({ title, items }: { title: string; items: BacklogItem[] }) {
+  return (
+    <div className="rounded-lg border p-4">
+      <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+      <div className="mt-3 space-y-2 text-sm">
+        {items.length ? (
+          items.map((item) => (
+            <div key={item.label} className="flex items-center justify-between">
+              <span className="capitalize">{item.label}</span>
+              <span className="font-semibold text-foreground">
+                {item.value}
+                {item.helper ? (
+                  <span className="ml-1 text-xs text-muted-foreground">{item.helper}</span>
+                ) : null}
+              </span>
+            </div>
+          ))
+        ) : (
+          <p className="text-xs text-muted-foreground">Tidak ada data</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TicketRepliesPreview({ ticket }: { ticket: Ticket }) {
+  const {
+    data: replies,
+    error,
+    isLoading,
+    mutate,
+  } = useSWR<TicketReply[]>(
+    ["vendor-dashboard", "support-health", "replies", ticket.id],
+    async ([, , , id]) => ensureSuccess(await listTicketReplies(id as string, { limit: 5 })),
+    {
+      revalidateOnFocus: false,
+    },
+  );
+
+  const latestReply = replies && replies.length ? replies[replies.length - 1] : null;
+
+  return (
+    <div className="rounded-lg border p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+            <MessageCircle className="h-4 w-4 text-primary" />
+            #{ticket.id} • {ticket.title}
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Status {formatTicketStatus(ticket.status)} • Prioritas {formatTicketPriority(ticket.priority)}
+          </p>
+        </div>
+        <Button size="sm" variant="outline" onClick={() => mutate()}>
+          Segarkan
+        </Button>
+      </div>
+      <div className="mt-3 text-sm text-muted-foreground">
+        {error ? (
+          <span>
+            {error instanceof Error
+              ? error.message
+              : "Gagal memuat balasan vendor."}
+          </span>
+        ) : isLoading && !replies ? (
+          <Skeleton className="h-16 w-full" />
+        ) : latestReply ? (
+          <>
+            <p className="font-medium text-foreground">{latestReply.message}</p>
+            <p className="mt-2 text-xs text-muted-foreground">
+              {formatReplyTimestamp(latestReply.created_at)} oleh agen #{latestReply.user_id}
+            </p>
+          </>
+        ) : (
+          <span>Belum ada balasan vendor untuk tiket ini.</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function filterTicketsByScope(
+  tickets: Ticket[],
+  filteredClientIds: Set<number>,
+  ranges: VendorDashboardResolvedRanges,
+) {
+  const { start, end } = ranges.current;
+  return tickets.filter((ticket) => {
+    if (filteredClientIds.size && !filteredClientIds.has(ticket.tenant_id)) {
+      return false;
+    }
+    const createdAt = parseISO(ticket.created_at);
+    if (Number.isNaN(createdAt.getTime())) return false;
+    return isWithinInterval(createdAt, { start, end });
+  });
+}
+
+type SupportMetrics = {
+  totalTickets: number;
+  openTickets: number;
+  responseCompliance: number | null;
+  resolutionCompliance: number | null;
+  avgFirstResponseMinutes: number | null;
+  avgResolutionMinutes: number | null;
+};
+
+function computeSupportMetrics(tickets: Ticket[]): SupportMetrics {
+  const totalTickets = tickets.length;
+  const openTickets = tickets.filter((ticket) => ticket.status !== "closed").length;
+
+  const responseTracked = tickets.filter((ticket) =>
+    typeof ticket.first_response_sla_delta_minutes === "number"
+  );
+  const responseMet = responseTracked.filter(
+    (ticket) => (ticket.first_response_sla_delta_minutes ?? 0) <= 0,
+  );
+  const resolutionTracked = tickets.filter((ticket) =>
+    typeof ticket.resolution_sla_delta_minutes === "number"
+  );
+  const resolutionMet = resolutionTracked.filter(
+    (ticket) => (ticket.resolution_sla_delta_minutes ?? 0) <= 0,
+  );
+
+  const responseCompliance = responseTracked.length
+    ? (responseMet.length / responseTracked.length) * 100
+    : null;
+  const resolutionCompliance = resolutionTracked.length
+    ? (resolutionMet.length / resolutionTracked.length) * 100
+    : null;
+
+  const avgFirstResponseMinutes = averageMinutes(
+    tickets
+      .map((ticket) => ticket.first_response_minutes ?? null)
+      .filter((value): value is number => typeof value === "number" && value > 0),
+  );
+  const avgResolutionMinutes = averageMinutes(
+    tickets
+      .map((ticket) => ticket.resolution_minutes ?? null)
+      .filter((value): value is number => typeof value === "number" && value > 0),
+  );
+
+  return {
+    totalTickets,
+    openTickets,
+    responseCompliance,
+    resolutionCompliance,
+    avgFirstResponseMinutes,
+    avgResolutionMinutes,
+  };
+}
+
+function averageMinutes(values: number[]) {
+  if (!values.length) return null;
+  const total = values.reduce((sum, value) => sum + value, 0);
+  return total / values.length;
+}
+
+type BacklogSummary = {
+  statuses: BacklogItem[];
+  priorities: BacklogItem[];
+};
+
+function buildBacklogSummaries(tickets: Ticket[]): BacklogSummary {
+  const statusCounts = new Map<string, number>();
+  const priorityCounts = new Map<string, number>();
+
+  for (const ticket of tickets) {
+    if (ticket.status !== "closed") {
+      statusCounts.set(ticket.status, (statusCounts.get(ticket.status) ?? 0) + 1);
+    }
+    priorityCounts.set(ticket.priority, (priorityCounts.get(ticket.priority) ?? 0) + 1);
+  }
+
+  const statuses: BacklogItem[] = Array.from(statusCounts.entries())
+    .map(([status, value]) => ({
+      label: formatTicketStatus(status as Ticket["status"]),
+      value,
+    }))
+    .sort((a, b) => b.value - a.value);
+
+  const priorities: BacklogItem[] = Array.from(priorityCounts.entries())
+    .map(([priority, value]) => ({
+      label: formatTicketPriority(priority as Ticket["priority"]),
+      value,
+    }))
+    .sort((a, b) => b.value - a.value);
+
+  return { statuses, priorities };
+}
+
+type AgentMetric = {
+  agentId: number;
+  totalTickets: number;
+  openTickets: number;
+  avgFirstResponseMinutes: number | null;
+  avgResolutionMinutes: number | null;
+};
+
+function computeAgentMetrics(tickets: Ticket[]): AgentMetric[] {
+  const byAgent = new Map<number, Ticket[]>();
+
+  for (const ticket of tickets) {
+    if (typeof ticket.agent_id !== "number") continue;
+    if (!byAgent.has(ticket.agent_id)) {
+      byAgent.set(ticket.agent_id, []);
+    }
+    byAgent.get(ticket.agent_id)?.push(ticket);
+  }
+
+  const agents: AgentMetric[] = Array.from(byAgent.entries()).map(([agentId, agentTickets]) => {
+    return {
+      agentId,
+      totalTickets: agentTickets.length,
+      openTickets: agentTickets.filter((ticket) => ticket.status !== "closed").length,
+      avgFirstResponseMinutes: averageMinutes(
+        agentTickets
+          .map((ticket) => ticket.first_response_minutes ?? null)
+          .filter((value): value is number => typeof value === "number" && value > 0),
+      ),
+      avgResolutionMinutes: averageMinutes(
+        agentTickets
+          .map((ticket) => ticket.resolution_minutes ?? null)
+          .filter((value): value is number => typeof value === "number" && value > 0),
+      ),
+    };
+  });
+
+  agents.sort((a, b) => b.totalTickets - a.totalTickets);
+
+  return agents.slice(0, 5);
+}
+
+function formatPercentage(value: number | null) {
+  if (value === null) return "Tidak tersedia";
+  return `${Math.round(value)}%`;
+}
+
+function formatMinutes(value: number | null) {
+  if (!value) return "-";
+  if (value < 60) {
+    return `${Math.round(value)} menit`;
+  }
+  const hours = Math.floor(value / 60);
+  const minutes = Math.round(value % 60);
+  if (hours >= 24) {
+    const days = Math.floor(hours / 24);
+    const remainingHours = hours % 24;
+    return `${days} hari ${remainingHours} jam ${minutes} menit`;
+  }
+  return `${hours} jam ${minutes} menit`;
+}
+
+function formatTicketStatus(status: Ticket["status"]) {
+  switch (status) {
+    case "open":
+      return "open";
+    case "in_progress":
+      return "dalam proses";
+    case "pending":
+      return "menunggu";
+    case "closed":
+      return "selesai";
+    default:
+      return status;
+  }
+}
+
+function formatTicketPriority(priority: Ticket["priority"]) {
+  switch (priority) {
+    case "low":
+      return "rendah";
+    case "medium":
+      return "sedang";
+    case "high":
+      return "tinggi";
+    default:
+      return priority;
+  }
+}
+
+function formatReplyTimestamp(value: string) {
+  try {
+    const parsed = parseISO(value);
+    const absolute = format(parsed, "d MMM yyyy HH:mm", { locale: localeId });
+    const relative = formatDistanceToNow(parsed, { addSuffix: true, locale: localeId });
+    return `${absolute} • ${relative}`;
+  } catch (_error) {
+    return value;
+  }
+}

--- a/src/app/(main)/vendor/dashboard/tenant-activity/page.tsx
+++ b/src/app/(main)/vendor/dashboard/tenant-activity/page.tsx
@@ -1,0 +1,738 @@
+/** @format */
+
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import useSWR from "swr";
+import Link from "next/link";
+import {
+  addDays,
+  eachDayOfInterval,
+  endOfWeek,
+  format,
+  formatDistanceToNow,
+  isWithinInterval,
+  parseISO,
+  startOfWeek,
+} from "date-fns";
+import { id as localeId } from "date-fns/locale";
+import { ActivitySquare, Filter, Flame } from "lucide-react";
+
+import { ensureSuccess } from "@/lib/api";
+import { getVendorUsageReport, listClientActivity } from "@/services/api";
+import type { ClientActivityEntry, VendorUsageReport } from "@/types/api";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+
+import { VendorDashboardGlobalFilters } from "@/components/feature/vendor/dashboard/vendor-dashboard-filters";
+import { useVendorDashboardFilters } from "@/components/feature/vendor/dashboard/vendor-dashboard-filter-context";
+import { useVendorDashboardTenantUniverse } from "@/components/feature/vendor/dashboard/vendor-dashboard-tenant-data";
+import {
+  resolveDashboardDateRanges,
+  type VendorDashboardResolvedRanges,
+} from "@/components/feature/vendor/dashboard/vendor-dashboard-date-utils";
+
+const currencyFormatter = new Intl.NumberFormat("id-ID", {
+  style: "currency",
+  currency: "IDR",
+  maximumFractionDigits: 0,
+});
+
+const tenantOptionAll = "all";
+const moduleOptionAll = "all";
+
+export default function VendorTenantActivityPage() {
+  const { filters } = useVendorDashboardFilters();
+  const ranges = useMemo(
+    () => resolveDashboardDateRanges(filters.dateRange ?? null),
+    [filters.dateRange],
+  );
+  const { filteredClients, tenantDataLoading } = useVendorDashboardTenantUniverse();
+
+  const [selectedTenant, setSelectedTenant] = useState<string>(tenantOptionAll);
+  const [selectedModule, setSelectedModule] = useState<string>(moduleOptionAll);
+
+  useEffect(() => {
+    if (
+      selectedTenant !== tenantOptionAll &&
+      !filteredClients.some((client) => String(client.id) === selectedTenant)
+    ) {
+      setSelectedTenant(tenantOptionAll);
+    }
+  }, [filteredClients, selectedTenant]);
+
+  const tenantId = selectedTenant === tenantOptionAll ? null : Number(selectedTenant);
+
+  const {
+    data: usageData,
+    error: usageError,
+    isLoading: usageLoading,
+    isValidating: usageValidating,
+    mutate: refreshUsage,
+  } = useSWR<VendorUsageReport>(
+    [
+      "vendor-dashboard",
+      "tenant-activity",
+      "usage",
+      tenantId ?? tenantOptionAll,
+      selectedModule,
+    ],
+    async () =>
+      ensureSuccess(
+        await getVendorUsageReport({
+          tenant: tenantId ?? undefined,
+          module: selectedModule !== moduleOptionAll ? selectedModule : undefined,
+        }),
+      ),
+    {
+      keepPreviousData: true,
+      revalidateOnFocus: false,
+    },
+  );
+
+  const {
+    heatmapMatrix,
+    heatmapSummary,
+    moduleOptions,
+    topDays,
+  } = useMemo(() => {
+    return transformUsageToHeatmap(
+      usageData,
+      tenantId,
+      selectedModule,
+      ranges,
+    );
+  }, [ranges, selectedModule, tenantId, usageData]);
+
+  const {
+    data: timelineData,
+    error: timelineError,
+    isLoading: timelineLoading,
+    mutate: refreshTimeline,
+  } = useSWR<ClientActivityEntry[]>(
+    tenantId
+      ? ["vendor-dashboard", "tenant-activity", "timeline", tenantId]
+      : null,
+    async ([, , , id]) =>
+      ensureSuccess(await listClientActivity(id as number, { limit: 50 })),
+    {
+      revalidateOnFocus: false,
+    },
+  );
+
+  const loadingHeatmap = usageLoading && !usageData;
+  const loadingTimeline = timelineLoading && !timelineData;
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-3">
+        <nav aria-label="Breadcrumb">
+          <ol className="flex items-center gap-2 text-sm text-muted-foreground">
+            <li>Vendor</li>
+            <li>/</li>
+            <li>Dashboard</li>
+            <li>/</li>
+            <li className="font-medium text-foreground">Aktivitas Tenant</li>
+          </ol>
+        </nav>
+        <div className="space-y-1">
+          <h1 className="text-3xl font-semibold tracking-tight">
+            Aktivitas Tenant & Modul
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Analisis intensitas login per hari dan linimasa aktivitas penting tenant.
+          </p>
+        </div>
+      </header>
+
+      <VendorDashboardGlobalFilters />
+
+      <Card>
+        <CardHeader className="flex flex-col gap-4 pb-3 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <Filter className="h-4 w-4" /> Filter Aktivitas
+            </CardTitle>
+            <CardDescription>
+              Pilih tenant dan modul untuk menelusuri intensitas login serta riwayat aktivitasnya.
+            </CardDescription>
+          </div>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <Select value={selectedTenant} onValueChange={setSelectedTenant}>
+              <SelectTrigger className="w-[240px]">
+                <SelectValue placeholder="Pilih tenant" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={tenantOptionAll}>Semua tenant tersaring</SelectItem>
+                {filteredClients.map((client) => (
+                  <SelectItem key={client.id} value={String(client.id)}>
+                    {client.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <Select
+              value={moduleOptions.some((option) => option.value === selectedModule)
+                ? selectedModule
+                : moduleOptionAll}
+              onValueChange={setSelectedModule}
+            >
+              <SelectTrigger className="w-[220px]">
+                <SelectValue placeholder="Pilih modul" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={moduleOptionAll}>Semua modul</SelectItem>
+                {moduleOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </CardHeader>
+        {tenantDataLoading ? (
+          <CardContent className="pb-6">
+            <Skeleton className="h-10 w-full" />
+          </CardContent>
+        ) : null}
+      </Card>
+
+      {usageError ? (
+        <Alert variant="destructive">
+          <AlertTitle>Data heatmap tidak dapat dimuat</AlertTitle>
+          <AlertDescription className="flex flex-col gap-3">
+            <span>
+              {usageError instanceof Error
+                ? usageError.message
+                : "Terjadi kesalahan saat mengambil data login tenant."}
+            </span>
+            <Button size="sm" variant="outline" onClick={() => refreshUsage()}>
+              Coba lagi
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      <div className="grid gap-6 xl:grid-cols-[2fr_1fr]">
+        <Card className="h-full">
+          <CardHeader className="flex flex-col gap-2 pb-2 sm:flex-row sm:items-start sm:justify-between">
+            <div className="space-y-1">
+              <CardTitle className="flex items-center gap-2 text-lg">
+                <Flame className="h-4 w-4 text-primary" />
+                Heatmap Login Tenant
+              </CardTitle>
+              <CardDescription>
+                Intensitas login harian berdasarkan rentang tanggal dan filter modul.
+              </CardDescription>
+            </div>
+            {usageValidating ? (
+              <span className="text-xs text-muted-foreground">Memperbarui data…</span>
+            ) : null}
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {loadingHeatmap ? (
+              <HeatmapSkeleton />
+            ) : heatmapMatrix.weeks.length ? (
+              <>
+                <HeatmapSummary summary={heatmapSummary} topDays={topDays} />
+                <TenantHeatmap matrix={heatmapMatrix} />
+              </>
+            ) : (
+              <div className="flex h-[260px] items-center justify-center rounded-lg border text-sm text-muted-foreground">
+                Tidak ada login yang tercatat untuk kombinasi filter ini.
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="h-full">
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <ActivitySquare className="h-4 w-4 text-primary" />
+              Timeline Aktivitas Tenant
+            </CardTitle>
+            <CardDescription>
+              Rekap tindakan terbaru dari API <code>GET /api/clients/:id/activity</code>.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {timelineError ? (
+              <Alert variant="destructive">
+                <AlertTitle>Linimasa tidak dapat dimuat</AlertTitle>
+                <AlertDescription className="flex flex-col gap-3">
+                  <span>
+                    {timelineError instanceof Error
+                      ? timelineError.message
+                      : "Terjadi kesalahan saat mengambil linimasa tenant."}
+                  </span>
+                  <Button size="sm" variant="outline" onClick={() => refreshTimeline()}>
+                    Muat ulang
+                  </Button>
+                </AlertDescription>
+              </Alert>
+            ) : null}
+
+            {!tenantId ? (
+              <div className="rounded-lg border bg-muted/30 p-4 text-sm text-muted-foreground">
+                Pilih tenant tertentu untuk melihat linimasa aktivitas lengkapnya.
+              </div>
+            ) : loadingTimeline ? (
+              <TimelineSkeleton />
+            ) : timelineData && timelineData.length ? (
+              <ul className="space-y-3">
+                {timelineData.map((entry, index) => (
+                  <li key={`${entry.occurred_at}-${entry.action}-${index}`}>
+                    <TimelineEntry entry={entry} />
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="rounded-lg border bg-muted/30 p-4 text-sm text-muted-foreground">
+                Tidak ada aktivitas terbaru yang ditemukan untuk tenant ini.
+              </div>
+            )}
+
+            <Separator />
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span>
+                Dokumentasi API:
+                <Link
+                  href="https://docs.koperasi.local/api/clients"
+                  className="ml-1 text-foreground underline"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  clients.activity
+                </Link>
+              </span>
+              {tenantId ? (
+                <Button size="sm" variant="outline" onClick={() => refreshTimeline()}>
+                  Segarkan
+                </Button>
+              ) : null}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+type HeatmapCell = {
+  date: Date;
+  count: number;
+  key: string;
+};
+
+type HeatmapMatrix = {
+  weeks: HeatmapCell[][];
+  weekdayLabels: string[];
+  weekLabels: string[];
+};
+
+type HeatmapSummary = {
+  totalLogins: number;
+  averagePerDay: number;
+  activeDays: number;
+  dateRangeLabel: string;
+};
+
+type HeatmapTopDay = {
+  date: string;
+  label: string;
+  count: number;
+};
+
+type HeatmapTransformResult = {
+  heatmapMatrix: HeatmapMatrix;
+  heatmapSummary: HeatmapSummary;
+  topDays: HeatmapTopDay[];
+  moduleOptions: Array<{ value: string; label: string }>;
+};
+
+function transformUsageToHeatmap(
+  usage: VendorUsageReport | undefined,
+  tenantId: number | null,
+  selectedModule: string,
+  ranges: VendorDashboardResolvedRanges,
+): HeatmapTransformResult {
+  const entries = extractModuleEntries(usage);
+  const moduleOptions = buildModuleOptions(entries);
+  const filteredEntries = entries.filter((entry) => {
+    if (selectedModule !== moduleOptionAll && entry.module !== selectedModule) {
+      return false;
+    }
+    return true;
+  });
+
+  const rangeStart = ranges.current.start;
+  const rangeEnd = ranges.current.end;
+  const counts = new Map<string, number>();
+
+  for (const entry of filteredEntries) {
+    for (const point of entry.points) {
+      if (tenantId && point.tenantId && point.tenantId !== tenantId) {
+        continue;
+      }
+      if (!point.date) continue;
+      const date = parseMaybeDate(point.date);
+      if (!date) continue;
+      if (!isWithinInterval(date, { start: rangeStart, end: rangeEnd })) {
+        continue;
+      }
+      const key = format(date, "yyyy-MM-dd");
+      const current = counts.get(key) ?? 0;
+      counts.set(key, current + Math.max(0, point.count ?? 0));
+    }
+  }
+
+  const start = startOfWeek(rangeStart, { weekStartsOn: 1 });
+  const end = endOfWeek(rangeEnd, { weekStartsOn: 1 });
+  const days = eachDayOfInterval({ start, end });
+  const weekdayLabels = ["Sen", "Sel", "Rab", "Kam", "Jum", "Sab", "Min"];
+  const weekLabels: string[] = [];
+  const weeks: HeatmapCell[][] = [];
+  let currentWeek: HeatmapCell[] = [];
+
+  days.forEach((day, index) => {
+    const key = format(day, "yyyy-MM-dd");
+    const count = counts.get(key) ?? 0;
+    currentWeek.push({ date: day, count, key });
+    if ((index + 1) % 7 === 0) {
+      weeks.push(currentWeek);
+      weekLabels.push(format(currentWeek[0].date, "d MMM"));
+      currentWeek = [];
+    }
+  });
+
+  if (currentWeek.length) {
+    while (currentWeek.length < 7) {
+      const last = currentWeek[currentWeek.length - 1];
+      const nextDate = addDays(last.date, 1);
+      currentWeek.push({ date: nextDate, count: 0, key: format(nextDate, "yyyy-MM-dd") });
+    }
+    weeks.push(currentWeek);
+    weekLabels.push(format(currentWeek[0].date, "d MMM"));
+  }
+
+  const totalLogins = Array.from(counts.values()).reduce(
+    (sum, value) => sum + value,
+    0,
+  );
+  const activeDays = Array.from(counts.values()).filter((value) => value > 0).length;
+  const averagePerDay = weeks.length ? totalLogins / days.length : 0;
+  const dateRangeLabel = `${format(rangeStart, "d MMM yyyy")} – ${format(rangeEnd, "d MMM yyyy")}`;
+
+  const topDays = Array.from(counts.entries())
+    .map(([key, count]) => {
+      const parsed = parseISO(`${key}T00:00:00Z`);
+      return {
+        date: key,
+        label: format(parsed, "d MMMM yyyy", { locale: localeId }),
+        count,
+      };
+    })
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 5);
+
+  return {
+    heatmapMatrix: { weeks, weekdayLabels, weekLabels },
+    heatmapSummary: { totalLogins, averagePerDay, activeDays, dateRangeLabel },
+    topDays,
+    moduleOptions,
+  };
+}
+
+type ModuleEntry = {
+  module: string;
+  label: string;
+  points: Array<{ date?: string; count?: number; tenantId?: number | null }>;
+};
+
+function extractModuleEntries(usage: VendorUsageReport | undefined): ModuleEntry[] {
+  if (!usage || typeof usage !== "object") return [];
+
+  const rawModules = Array.isArray((usage as any).module_usage)
+    ? ((usage as any).module_usage as unknown[])
+    : Array.isArray((usage as any).modules)
+      ? ((usage as any).modules as unknown[])
+      : [];
+
+  const entries: ModuleEntry[] = [];
+
+  for (const raw of rawModules) {
+    if (!raw || typeof raw !== "object") continue;
+    const moduleKey =
+      (raw as any).module_key ||
+      (raw as any).module ||
+      (raw as any).key ||
+      (raw as any).slug;
+    if (!moduleKey || typeof moduleKey !== "string") continue;
+    const label =
+      (raw as any).module_name ||
+      (raw as any).name ||
+      moduleKey
+        .replace(/[-_]/g, " ")
+        .replace(/\b\w/g, (char) => char.toUpperCase());
+
+    const pointsSource =
+      Array.isArray((raw as any).daily_logins)
+        ? (raw as any).daily_logins
+        : Array.isArray((raw as any).logins)
+          ? (raw as any).logins
+          : Array.isArray((raw as any).entries)
+            ? (raw as any).entries
+            : [];
+
+    const points = pointsSource
+      .map((point: any) => ({
+        date:
+          typeof point?.date === "string"
+            ? point.date
+            : typeof point?.day === "string"
+              ? point.day
+              : typeof point?.occurred_at === "string"
+                ? point.occurred_at
+                : typeof point?.timestamp === "string"
+                  ? point.timestamp
+                  : undefined,
+        count:
+          typeof point?.count === "number"
+            ? point.count
+            : typeof point?.logins === "number"
+              ? point.logins
+              : typeof point?.total === "number"
+                ? point.total
+                : undefined,
+        tenantId:
+          typeof point?.tenant_id === "number"
+            ? point.tenant_id
+            : typeof point?.tenantId === "number"
+              ? point.tenantId
+              : typeof point?.tenant === "number"
+                ? point.tenant
+                : null,
+      }))
+      .filter((point: { date?: string; count?: number | null }) => Boolean(point.date));
+
+    entries.push({ module: moduleKey, label, points });
+  }
+
+  return entries;
+}
+
+function buildModuleOptions(entries: ModuleEntry[]) {
+  const unique = new Map<string, string>();
+  for (const entry of entries) {
+    if (!unique.has(entry.module)) {
+      unique.set(entry.module, entry.label);
+    }
+  }
+  return Array.from(unique.entries()).map(([value, label]) => ({ value, label }));
+}
+
+function parseMaybeDate(value: string | undefined) {
+  if (!value) return null;
+  try {
+    const parsed = parseISO(value);
+    if (Number.isNaN(parsed.getTime())) {
+      const fallback = parseISO(`${value}T00:00:00`);
+      return Number.isNaN(fallback.getTime()) ? null : fallback;
+    }
+    return parsed;
+  } catch (_error) {
+    return null;
+  }
+}
+
+function HeatmapSummary({
+  summary,
+  topDays,
+}: {
+  summary: HeatmapSummary;
+  topDays: HeatmapTopDay[];
+}) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      <div className="rounded-lg border p-4">
+        <p className="text-xs text-muted-foreground">Rentang Analisis</p>
+        <p className="text-sm font-medium">{summary.dateRangeLabel}</p>
+        <div className="mt-4 grid grid-cols-2 gap-3 text-sm">
+          <div>
+            <p className="text-muted-foreground">Total Login</p>
+            <p className="text-xl font-semibold">{summary.totalLogins}</p>
+          </div>
+          <div>
+            <p className="text-muted-foreground">Rata-rata / hari</p>
+            <p className="text-xl font-semibold">
+              {summary.averagePerDay ? summary.averagePerDay.toFixed(1) : "0"}
+            </p>
+          </div>
+        </div>
+        <p className="mt-3 text-xs text-muted-foreground">
+          Aktivitas tercatat pada {summary.activeDays} hari unik.
+        </p>
+      </div>
+      <div className="rounded-lg border p-4">
+        <p className="text-xs font-medium text-muted-foreground">
+          Hari dengan login tertinggi
+        </p>
+        <ul className="mt-3 space-y-2 text-sm">
+          {topDays.length ? (
+            topDays.map((day) => (
+              <li key={day.date} className="flex items-center justify-between">
+                <span>{day.label}</span>
+                <span className="font-semibold">{day.count}</span>
+              </li>
+            ))
+          ) : (
+            <li className="text-muted-foreground">Belum ada data menonjol.</li>
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function TenantHeatmap({ matrix }: { matrix: HeatmapMatrix }) {
+  const maxValue = matrix.weeks.reduce((max, week) => {
+    return Math.max(max, ...week.map((cell) => cell.count));
+  }, 0);
+
+  const legendSteps = [0, 0.25, 0.5, 0.75, 1];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-4 overflow-x-auto">
+        <div className="flex flex-col justify-between py-4 pr-2 text-xs text-muted-foreground">
+          {matrix.weekdayLabels.map((label) => (
+            <span key={label} className="h-8 leading-8">
+              {label}
+            </span>
+          ))}
+        </div>
+        <div className="flex gap-1">
+          {matrix.weeks.map((week, weekIndex) => (
+            <div key={weekIndex} className="flex flex-col gap-1">
+              {week.map((cell) => (
+                <div
+                  key={cell.key}
+                  className={computeHeatmapCellClass(cell.count, maxValue)}
+                  title={`${format(cell.date, "d MMM yyyy", { locale: localeId })} • ${cell.count} login`}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span>Intensitas login</span>
+        <div className="flex items-center gap-2">
+          {legendSteps.map((step, index) => (
+            <div key={index} className="flex items-center gap-1">
+              <span
+                className={computeHeatmapCellClass(
+                  step === 0 ? 0 : step * (maxValue || 1),
+                  maxValue || 1,
+                )}
+              />
+              <span>{Math.round(step * 100)}%</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function computeHeatmapCellClass(value: number, maxValue: number) {
+  if (!maxValue || value <= 0) {
+    return "h-8 w-4 rounded-sm border border-dashed border-muted";
+  }
+  const ratio = value / maxValue;
+  if (ratio >= 0.85) return "h-8 w-4 rounded-sm bg-emerald-600";
+  if (ratio >= 0.6) return "h-8 w-4 rounded-sm bg-emerald-500";
+  if (ratio >= 0.35) return "h-8 w-4 rounded-sm bg-emerald-400";
+  return "h-8 w-4 rounded-sm bg-emerald-300";
+}
+
+function TimelineEntry({ entry }: { entry: ClientActivityEntry }) {
+  const occurred = parseMaybeDate(entry.occurred_at ?? undefined);
+  const occurredLabel = occurred
+    ? format(occurred, "d MMM yyyy HH:mm", { locale: localeId })
+    : "-";
+  const relativeLabel = occurred
+    ? formatDistanceToNow(occurred, { addSuffix: true, locale: localeId })
+    : "";
+
+  return (
+    <div className="space-y-2 rounded-lg border p-4">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="outline" className="uppercase tracking-tight">
+            {entry.type}
+          </Badge>
+          <span className="font-semibold">{entry.action}</span>
+          {entry.status ? (
+            <Badge variant="secondary" className="capitalize">
+              {entry.status.replace(/_/g, " ")}
+            </Badge>
+          ) : null}
+        </div>
+        <div className="text-right text-xs text-muted-foreground">
+          <div>{occurredLabel}</div>
+          <div>{relativeLabel}</div>
+        </div>
+      </div>
+      {entry.message ? (
+        <p className="text-sm text-muted-foreground">{entry.message}</p>
+      ) : null}
+      {typeof entry.amount === "number" ? (
+        <p className="text-sm font-semibold text-emerald-600">
+          {currencyFormatter.format(entry.amount)}
+        </p>
+      ) : null}
+      {entry.reference ? (
+        <p className="text-xs text-muted-foreground">Ref: {entry.reference}</p>
+      ) : null}
+    </div>
+  );
+}
+
+function HeatmapSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-20 w-full" />
+      <Skeleton className="h-[220px] w-full" />
+    </div>
+  );
+}
+
+function TimelineSkeleton() {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: 4 }).map((_, index) => (
+        <Skeleton key={index} className="h-24 w-full" />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a vendor dashboard layout that provides shared filters and navigation for the new drilldown routes
- implement tenant activity, revenue trend, and support health sub-pages with dedicated data fetching, visualisations, and error handling
- surface quick links from the main vendor dashboard to access the detailed analytics pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0f91ddcbc8322b454b23183836369